### PR TITLE
feat: add smart money divergence indicator

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -57,6 +57,7 @@ from metrics import (
     compute_aggressor_ratio_series,
     compute_kalman_price,
     compute_ob_pressure_gradient,
+    compute_smart_money_divergence,
 )
 
 router = APIRouter(prefix="/api")
@@ -3295,4 +3296,82 @@ async def vwap_band_endpoint(
         "description": desc,
         "window_seconds": window,
         "bucket_size": bucket,
+    }
+
+
+@router.get("/smart-money-divergence")
+async def smart_money_divergence_endpoint(
+    symbol: str = Query(..., description="Symbol e.g. BTCUSDT"),
+    window: int = Query(default=1800, ge=300, le=86400, description="Lookback in seconds (default 30m)"),
+    threshold_usd: float = Query(default=10000.0, ge=100.0, description="Smart money trade size threshold in USD"),
+    bucket_seconds: int = Query(default=300, ge=60, le=3600, description="Bucket width in seconds"),
+):
+    """
+    Smart money divergence for a single symbol.
+
+    Classifies trades as smart (value >= threshold_usd) or retail (< threshold_usd),
+    computes cumulative delta for each group, and returns a divergence score.
+
+    Returns:
+      smart_cvd, retail_cvd, divergence_score, signal, smart_pct,
+      divergence_detected, buckets[{ts, smart_cvd, retail_cvd}]
+    """
+    since = time.time() - window
+    trades = await get_recent_trades(symbol=symbol, since=since, limit=50000)
+
+    result = compute_smart_money_divergence(
+        trades,
+        threshold_usd=threshold_usd,
+        bucket_seconds=bucket_seconds,
+    )
+
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        "threshold_usd": threshold_usd,
+        **result,
+    }
+
+
+@router.get("/smart-money-divergence/all")
+async def smart_money_divergence_all_endpoint(
+    window: int = Query(default=1800, ge=300, le=86400, description="Lookback in seconds (default 30m)"),
+    threshold_usd: float = Query(default=10000.0, ge=100.0, description="Smart money trade size threshold in USD"),
+    bucket_seconds: int = Query(default=300, ge=60, le=3600, description="Bucket width in seconds"),
+):
+    """
+    Smart money divergence for ALL tracked symbols in parallel.
+
+    Returns a list of per-symbol results sorted by divergence_score descending.
+    """
+    symbols = get_symbols()
+    if not symbols:
+        return {"error": "No symbols configured"}
+
+    since = time.time() - window
+    trade_lists = await asyncio.gather(*[
+        get_recent_trades(symbol=sym, since=since, limit=50000)
+        for sym in symbols
+    ])
+
+    results = []
+    for sym, trades in zip(symbols, trade_lists):
+        r = compute_smart_money_divergence(
+            trades,
+            threshold_usd=threshold_usd,
+            bucket_seconds=bucket_seconds,
+        )
+        results.append({
+            "symbol": sym,
+            **r,
+        })
+
+    results.sort(key=lambda x: x["divergence_score"], reverse=True)
+
+    return {
+        "status": "ok",
+        "window_seconds": window,
+        "threshold_usd": threshold_usd,
+        "symbols": results,
     }

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -2559,3 +2559,120 @@ async def compute_ob_pressure_gradient(
         "window_seconds": window_seconds,
         "bucket_size": bucket_size,
     }
+
+
+def compute_smart_money_divergence(
+    trades: List[dict],
+    threshold_usd: float = 10000.0,
+    bucket_seconds: int = 300,
+) -> dict:
+    """Detect divergence between large-trade (smart money) and retail flow.
+
+    Retail CVD = cumulative delta of trades where price*qty < threshold_usd
+    Smart CVD  = cumulative delta of trades where price*qty >= threshold_usd
+    delta uses is_buyer_aggressor when present, falls back to side field.
+
+    divergence_score = (smart_cvd - retail_cvd) / (|smart_cvd| + |retail_cvd| + 1e-8)
+
+    Signals:
+        accumulation  score >= 0.15   (smart buying vs retail selling)
+        distribution  score <= -0.15  (smart selling vs retail buying)
+        aligned       |score| < 0.15 and both same direction
+        neutral       |score| < 0.15 otherwise
+
+    Returns:
+        {smart_cvd, retail_cvd, smart_trade_count, retail_trade_count,
+         divergence_score, signal, smart_pct, divergence_detected,
+         buckets: [{ts, smart_cvd, retail_cvd}]}
+    """
+    smart_buy = smart_sell = 0.0
+    retail_buy = retail_sell = 0.0
+    smart_count = retail_count = 0
+    smart_vol_total = retail_vol_total = 0.0
+
+    # {ts_bucket: {smart_buy, smart_sell, retail_buy, retail_sell}}
+    bucket_map: dict = {}
+
+    for t in trades:
+        price = float(t["price"])
+        qty   = float(t["qty"])
+        val   = price * qty
+
+        # Determine taker direction
+        iba = t.get("is_buyer_aggressor")
+        if iba is not None:
+            is_buy = bool(iba)
+        else:
+            is_buy = (t.get("side") or "").lower() == "buy"
+
+        ts_b = int(float(t["ts"]) // bucket_seconds) * bucket_seconds
+        if ts_b not in bucket_map:
+            bucket_map[ts_b] = {"smart_buy": 0.0, "smart_sell": 0.0,
+                                "retail_buy": 0.0, "retail_sell": 0.0}
+
+        if val >= threshold_usd:
+            smart_count += 1
+            smart_vol_total += val
+            if is_buy:
+                smart_buy += val
+                bucket_map[ts_b]["smart_buy"] += val
+            else:
+                smart_sell += val
+                bucket_map[ts_b]["smart_sell"] += val
+        else:
+            retail_count += 1
+            retail_vol_total += val
+            if is_buy:
+                retail_buy += val
+                bucket_map[ts_b]["retail_buy"] += val
+            else:
+                retail_sell += val
+                bucket_map[ts_b]["retail_sell"] += val
+
+    smart_cvd  = smart_buy  - smart_sell
+    retail_cvd = retail_buy - retail_sell
+
+    total_vol = abs(smart_cvd) + abs(retail_cvd) + 1e-8
+    divergence_score = (smart_cvd - retail_cvd) / total_vol
+
+    # Signal classification
+    smart_dir  = 1 if smart_cvd  > 0 else (-1 if smart_cvd  < 0 else 0)
+    retail_dir = 1 if retail_cvd > 0 else (-1 if retail_cvd < 0 else 0)
+    same_dir   = (smart_dir != 0 and retail_dir != 0 and smart_dir == retail_dir)
+
+    if divergence_score >= 0.15:
+        signal = "accumulation"
+    elif divergence_score <= -0.15:
+        signal = "distribution"
+    elif same_dir:
+        signal = "aligned"
+    else:
+        signal = "neutral"
+
+    divergence_detected = signal in ("accumulation", "distribution")
+
+    # smart_pct = smart vol / (smart vol + retail vol)
+    all_vol = smart_vol_total + retail_vol_total
+    smart_pct = (smart_vol_total / all_vol) if all_vol > 0 else 0.0
+
+    # Build bucket series sorted ascending
+    buckets = []
+    for ts_b in sorted(bucket_map):
+        bm = bucket_map[ts_b]
+        buckets.append({
+            "ts":         float(ts_b),
+            "smart_cvd":  round(bm["smart_buy"] - bm["smart_sell"],  4),
+            "retail_cvd": round(bm["retail_buy"] - bm["retail_sell"], 4),
+        })
+
+    return {
+        "smart_cvd":          round(smart_cvd,  4),
+        "retail_cvd":         round(retail_cvd, 4),
+        "smart_trade_count":  smart_count,
+        "retail_trade_count": retail_count,
+        "divergence_score":   round(divergence_score, 6),
+        "signal":             signal,
+        "smart_pct":          round(smart_pct, 6),
+        "divergence_detected": divergence_detected,
+        "buckets":            buckets,
+    }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1081,6 +1081,17 @@
     <canvas id="chart-liq" style="margin-top:10px;"></canvas>
   </div>
 
+  <!-- Smart Money Divergence -->
+  <div class="card wide" id="card-smart-money">
+    <h2><span class="card-icon">🧿</span>Smart Money Divergence (30m)
+      <span id="smd-badge" style="margin-left:8px;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:700;display:none;"></span>
+      <span id="smd-ts" style="margin-left:auto;font-size:10px;color:var(--muted);font-weight:400;letter-spacing:0;text-transform:none;"></span>
+    </h2>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:8px;">smart = trades ≥$10k · retail = trades &lt;$10k · divergence = smart buying while retail sells (or vice versa)</div>
+    <div id="smd-metrics" style="display:flex;gap:16px;flex-wrap:wrap;font-size:11px;margin-bottom:10px;"></div>
+    <canvas id="chart-smart-money" style="height:130px !important;"></canvas>
+  </div>
+
   <!-- Whale Trades -->
   <div class="card" id="card-whales">
     <h2><span class="card-icon">🐳</span>Whale Trades &gt;$50k (1h)
@@ -2289,6 +2300,53 @@ function initRsiChart() {
   });
 }
 
+// Smart Money Divergence dual-line chart
+let chartSmartMoney = null;
+(function initSmartMoneyChart() {
+  const ctx = document.getElementById('chart-smart-money');
+  if (!ctx) return;
+  chartSmartMoney = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'Smart CVD',
+          data: [],
+          borderColor: 'rgba(0,220,120,0.9)',
+          backgroundColor: 'rgba(0,220,120,0.08)',
+          borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: true,
+          yAxisID: 'ySmart',
+        },
+        {
+          label: 'Retail CVD',
+          data: [],
+          borderColor: 'rgba(255,160,50,0.9)',
+          backgroundColor: 'rgba(255,160,50,0.08)',
+          borderWidth: 1.5, pointRadius: 0, tension: 0.3, fill: true,
+          yAxisID: 'yRetail',
+        },
+      ],
+    },
+    options: {
+      animation: false, responsive: true, maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { display: true, labels: { color: 'rgba(200,200,200,0.7)', font: { size: 9 }, boxWidth: 10 } },
+        tooltip: { callbacks: { label: ctx => {
+          const v = ctx.parsed.y;
+          return `${ctx.dataset.label}: ${v >= 0 ? '+' : ''}${v.toFixed(2)}`;
+        }}},
+      },
+      scales: {
+        x: { ticks: { color: 'rgba(200,200,200,0.5)', font: { size: 8 }, maxTicksLimit: 10, maxRotation: 0 }, grid: { color: 'rgba(255,255,255,0.04)' } },
+        ySmart:  { position: 'left',  ticks: { color: 'rgba(0,220,120,0.7)',   font: { size: 8 } }, grid: { color: 'rgba(255,255,255,0.04)' } },
+        yRetail: { position: 'right', ticks: { color: 'rgba(255,160,50,0.7)',  font: { size: 8 } }, grid: { drawOnChartArea: false } },
+      },
+    },
+  });
+})();
+
 // ── Sparklines ────────────────────────────────────────────────────────────────
 const sparklines = {};
 function mkSparkline(id, color) {
@@ -3024,7 +3082,7 @@ async function refreshAll() {
   if (!activeSymbol) return;
   const sym = encodeURIComponent(activeSymbol);
 
-  const [cvd, oi, funding, liqs, vp, divg, ltrades, oisp, liqcas, volspike, whales, patternLive, patternHist, oiDelta, tradeRate, spreadData, flowImb] = await Promise.all([
+  const [cvd, oi, funding, liqs, vp, divg, ltrades, oisp, liqcas, volspike, whales, patternLive, patternHist, oiDelta, tradeRate, spreadData, flowImb, smd] = await Promise.all([
     fetchJSON(`/api/cvd/history?window=3600&symbol=${sym}`),
     fetchJSON(`/api/oi/history?limit=300&symbol=${sym}`),
     fetchJSON(`/api/funding/history?limit=200&symbol=${sym}`),
@@ -3042,6 +3100,7 @@ async function refreshAll() {
     fetchJSON(`/api/trade-count-rate?interval=60&window=1800&symbol=${sym}`),
     fetchJSON(`/api/spread-tracker?window=1800&symbol=${sym}`),
     fetchJSON(`/api/flow-imbalance?window=3600&bucket_size=60&symbol=${sym}`),
+    fetchJSON(`/api/smart-money-divergence?window=1800&threshold_usd=10000&bucket_seconds=300&symbol=${sym}`),
   ]);
 
   // CVD + Price dual-axis chart
@@ -3213,6 +3272,68 @@ async function refreshAll() {
       const biasColor = sm.bias === 'buy' ? 'var(--green)' : sm.bias === 'sell' ? 'var(--red)' : 'var(--muted)';
       infoEl.innerHTML = `<span style="color:${biasColor};font-weight:700;">${sm.bias?.toUpperCase()}</span> `
         + `avg: ${(sm.avg_ratio * 100).toFixed(1)}% · strength: ${sm.bias_strength?.toFixed(1)}`;
+    }
+  }
+
+  // ── Smart Money Divergence ────────────────────────────────────────────────
+  if (smd) {
+    const badgeEl   = document.getElementById('smd-badge');
+    const tsEl      = document.getElementById('smd-ts');
+    const metricsEl = document.getElementById('smd-metrics');
+
+    const signalColors = {
+      accumulation: { bg: 'rgba(0,200,120,0.25)', color: 'var(--green)', label: 'ACCUMULATION' },
+      distribution:  { bg: 'rgba(220,60,60,0.25)',  color: 'var(--red)',   label: 'DISTRIBUTION'  },
+      aligned:       { bg: 'rgba(100,180,255,0.2)',  color: '#64b4ff',     label: 'ALIGNED'        },
+      neutral:       { bg: 'rgba(120,120,120,0.2)',  color: 'var(--muted)', label: 'NEUTRAL'       },
+    };
+
+    const sc = signalColors[smd.signal] || signalColors.neutral;
+    if (badgeEl) {
+      badgeEl.textContent = sc.label;
+      badgeEl.style.background = sc.bg;
+      badgeEl.style.color = sc.color;
+      badgeEl.style.display = 'inline-block';
+    }
+    if (tsEl) tsEl.textContent = 'last 30m';
+
+    if (metricsEl) {
+      const scoreCol = smd.divergence_score > 0.15 ? 'var(--green)' : smd.divergence_score < -0.15 ? 'var(--red)' : 'var(--muted)';
+      const scoreSign = smd.divergence_score >= 0 ? '+' : '';
+      const smartNetCol = smd.smart_cvd > 0 ? 'var(--green)' : smd.smart_cvd < 0 ? 'var(--red)' : 'var(--muted)';
+      const retNetCol = smd.retail_cvd > 0 ? 'var(--green)' : smd.retail_cvd < 0 ? 'var(--red)' : 'var(--muted)';
+      const smartPctPct = (smd.smart_pct * 100).toFixed(1);
+
+      metricsEl.innerHTML = [
+        `<div style="background:rgba(0,220,120,0.1);border:1px solid rgba(0,220,120,0.2);border-radius:6px;padding:6px 12px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:3px;">Smart CVD</div>
+          <div style="color:${smartNetCol};font-size:14px;font-weight:700;">${smd.smart_cvd >= 0 ? '+' : ''}${smd.smart_cvd.toFixed(2)}</div>
+          <div style="color:var(--muted);font-size:9px;">${smd.smart_trade_count} trades</div>
+        </div>`,
+        `<div style="background:rgba(255,160,50,0.1);border:1px solid rgba(255,160,50,0.2);border-radius:6px;padding:6px 12px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:3px;">Retail CVD</div>
+          <div style="color:${retNetCol};font-size:14px;font-weight:700;">${smd.retail_cvd >= 0 ? '+' : ''}${smd.retail_cvd.toFixed(2)}</div>
+          <div style="color:var(--muted);font-size:9px;">${smd.retail_trade_count} trades</div>
+        </div>`,
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:6px 12px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:3px;">Divergence Score</div>
+          <div style="color:${scoreCol};font-size:14px;font-weight:700;">${scoreSign}${smd.divergence_score.toFixed(3)}</div>
+          <div style="color:var(--muted);font-size:9px;">[-1 distrib → +1 accum]</div>
+        </div>`,
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:6px 12px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:3px;">Smart Vol %</div>
+          <div style="color:var(--yellow);font-size:14px;font-weight:700;">${smartPctPct}%</div>
+          <div style="color:var(--muted);font-size:9px;">of total volume</div>
+        </div>`,
+      ].join('');
+    }
+
+    if (chartSmartMoney && smd.buckets?.length) {
+      const buckets = smd.buckets;
+      chartSmartMoney.data.labels = buckets.map(b => fmtTs(b.ts));
+      chartSmartMoney.data.datasets[0].data = buckets.map(b => b.smart_cvd);
+      chartSmartMoney.data.datasets[1].data = buckets.map(b => b.retail_cvd);
+      chartSmartMoney.update('none');
     }
   }
 

--- a/tests/test_smart_money_divergence.py
+++ b/tests/test_smart_money_divergence.py
@@ -1,0 +1,353 @@
+"""
+TDD tests for smart money divergence detector.
+
+Spec: docs/superpowers/specs/2026-03-15-smart-money-divergence.md
+
+Pure function: compute_smart_money_divergence(trades, threshold_usd, bucket_seconds)
+
+Retail CVD  = cumulative delta of trades where price*qty < threshold_usd
+Smart CVD   = cumulative delta of trades where price*qty >= threshold_usd
+delta uses is_buyer_aggressor when present, falls back to side field
+
+divergence_score = (smart_cvd - retail_cvd) / (abs(smart_cvd) + abs(retail_cvd) + 1e-8)
+
+Signals:
+  |score| < 0.15 and same direction  → "aligned"
+  |score| < 0.15 and diff/no dir     → "neutral"
+  score >= 0.15                       → "accumulation"
+  score <= -0.15                      → "distribution"
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from metrics import compute_smart_money_divergence  # noqa: E402
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _trade(ts, price, qty, side="buy", is_buyer_aggressor=None):
+    d = {"ts": float(ts), "price": float(price), "qty": float(qty), "side": side}
+    if is_buyer_aggressor is not None:
+        d["is_buyer_aggressor"] = int(is_buyer_aggressor)
+    return d
+
+
+def _large_buy(ts=0, usd=50000):
+    """Large buy: price*qty >= threshold."""
+    return _trade(ts, price=usd, qty=1.0, side="buy")
+
+def _large_sell(ts=0, usd=50000):
+    return _trade(ts, price=usd, qty=1.0, side="sell")
+
+def _small_buy(ts=0, usd=500):
+    return _trade(ts, price=usd, qty=1.0, side="buy")
+
+def _small_sell(ts=0, usd=500):
+    return _trade(ts, price=usd, qty=1.0, side="sell")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Structure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStructure:
+    def test_empty_trades_returns_valid_dict(self):
+        r = compute_smart_money_divergence([], threshold_usd=10000, bucket_seconds=300)
+        assert isinstance(r, dict)
+
+    def test_result_has_required_fields(self):
+        r = compute_smart_money_divergence([_large_buy()], threshold_usd=10000)
+        for f in ("smart_cvd", "retail_cvd", "smart_trade_count", "retail_trade_count",
+                  "divergence_score", "signal", "smart_pct", "divergence_detected", "buckets"):
+            assert f in r, f"missing: {f}"
+
+    def test_bucket_has_required_fields(self):
+        r = compute_smart_money_divergence([_large_buy(ts=0), _small_buy(ts=1)],
+                                           threshold_usd=10000, bucket_seconds=300)
+        b = r["buckets"][0]
+        for f in ("ts", "smart_cvd", "retail_cvd"):
+            assert f in b, f"missing bucket field: {f}"
+
+    def test_empty_gives_neutral_signal(self):
+        r = compute_smart_money_divergence([])
+        assert r["signal"] == "neutral"
+        assert r["divergence_detected"] is False
+
+    def test_all_values_zero_on_empty(self):
+        r = compute_smart_money_divergence([])
+        assert r["smart_cvd"] == pytest.approx(0.0)
+        assert r["retail_cvd"] == pytest.approx(0.0)
+        assert r["smart_trade_count"] == 0
+        assert r["retail_trade_count"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Trade classification
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTradeClassification:
+    def test_large_buy_goes_to_smart_cvd(self):
+        r = compute_smart_money_divergence([_large_buy(usd=50000)], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(50000.0)
+        assert r["retail_cvd"] == pytest.approx(0.0)
+
+    def test_large_sell_goes_to_smart_cvd_negative(self):
+        r = compute_smart_money_divergence([_large_sell(usd=50000)], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(-50000.0)
+
+    def test_small_buy_goes_to_retail_cvd(self):
+        r = compute_smart_money_divergence([_small_buy(usd=500)], threshold_usd=10000)
+        assert r["retail_cvd"] == pytest.approx(500.0)
+        assert r["smart_cvd"] == pytest.approx(0.0)
+
+    def test_small_sell_goes_to_retail_cvd_negative(self):
+        r = compute_smart_money_divergence([_small_sell(usd=500)], threshold_usd=10000)
+        assert r["retail_cvd"] == pytest.approx(-500.0)
+
+    def test_exactly_at_threshold_is_smart(self):
+        """price*qty == threshold_usd → smart (>=)."""
+        t = _trade(0, price=10000.0, qty=1.0, side="buy")
+        r = compute_smart_money_divergence([t], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(10000.0)
+        assert r["smart_trade_count"] == 1
+        assert r["retail_trade_count"] == 0
+
+    def test_just_below_threshold_is_retail(self):
+        t = _trade(0, price=9999.99, qty=1.0, side="buy")
+        r = compute_smart_money_divergence([t], threshold_usd=10000)
+        assert r["retail_cvd"] == pytest.approx(9999.99)
+        assert r["retail_trade_count"] == 1
+        assert r["smart_trade_count"] == 0
+
+    def test_trade_counts_correct(self):
+        trades = [_large_buy(ts=i) for i in range(3)] + [_small_buy(ts=i+10) for i in range(7)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["smart_trade_count"] == 3
+        assert r["retail_trade_count"] == 7
+
+    def test_value_usd_uses_price_times_qty(self):
+        """value = price * qty, not just price."""
+        t = _trade(0, price=200.0, qty=60.0, side="buy")   # 200*60=12000 → smart
+        r = compute_smart_money_divergence([t], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(12000.0)
+        assert r["smart_trade_count"] == 1
+
+    def test_is_buyer_aggressor_true_overrides_side(self):
+        """is_buyer_aggressor=True → buy regardless of side field."""
+        t = _trade(0, price=50000.0, qty=1.0, side="sell", is_buyer_aggressor=True)
+        r = compute_smart_money_divergence([t], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(50000.0)   # treated as buy
+
+    def test_is_buyer_aggressor_false_overrides_side(self):
+        t = _trade(0, price=50000.0, qty=1.0, side="buy", is_buyer_aggressor=False)
+        r = compute_smart_money_divergence([t], threshold_usd=10000)
+        assert r["smart_cvd"] == pytest.approx(-50000.0)  # treated as sell
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Divergence score
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDivergenceScore:
+    def test_score_formula(self):
+        """divergence_score = (smart_cvd - retail_cvd) / (|smart_cvd| + |retail_cvd| + 1e-8)."""
+        # Use threshold=50 so price=100 is smart and price=30 is retail
+        trades = [_trade(0, price=100.0, qty=1.0, side="buy"),   # smart: 100 >= 50
+                  _trade(1, price=30.0,  qty=1.0, side="sell")]  # retail: 30 < 50
+        r = compute_smart_money_divergence(trades, threshold_usd=50)
+        # smart_cvd=+100, retail_cvd=-30
+        expected = (100 - (-30)) / (100 + 30 + 1e-8)
+        assert r["divergence_score"] == pytest.approx(expected, rel=1e-4)
+
+    def test_score_range_minus_one_to_one(self):
+        import random; random.seed(42)
+        trades = [
+            _trade(i, price=random.uniform(100, 50000), qty=random.uniform(0.1, 10),
+                   side=random.choice(["buy","sell"]))
+            for i in range(50)
+        ]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert -1.0 <= r["divergence_score"] <= 1.0
+
+    def test_perfect_accumulation_score_near_one(self):
+        """Smart buys only, retail sells only → score ≈ +1."""
+        trades = [_large_buy(usd=50000, ts=i) for i in range(5)] + \
+                 [_small_sell(usd=100, ts=i+10) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        # smart=+250000, retail=-500 → score near +1
+        assert r["divergence_score"] > 0.9
+
+    def test_perfect_distribution_score_near_minus_one(self):
+        """Smart sells only, retail buys only → score ≈ -1."""
+        trades = [_large_sell(usd=50000, ts=i) for i in range(5)] + \
+                 [_small_buy(usd=100, ts=i+10) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["divergence_score"] < -0.9
+
+    def test_empty_score_is_zero(self):
+        r = compute_smart_money_divergence([])
+        assert r["divergence_score"] == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Signals
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSignals:
+    def test_smart_buy_retail_sell_is_accumulation(self):
+        """Classic accumulation: smart buying, retail selling."""
+        trades = [_large_buy(usd=50000, ts=i) for i in range(5)] + \
+                 [_small_sell(usd=500, ts=i+10) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["signal"] == "accumulation"
+        assert r["divergence_detected"] is True
+
+    def test_smart_sell_retail_buy_is_distribution(self):
+        """Classic distribution: smart selling, retail buying."""
+        trades = [_large_sell(usd=50000, ts=i) for i in range(5)] + \
+                 [_small_buy(usd=500, ts=i+10) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["signal"] == "distribution"
+        assert r["divergence_detected"] is True
+
+    def test_both_buy_similar_magnitude_is_aligned(self):
+        """Smart and retail both buying proportionally → aligned (low divergence score)."""
+        # threshold=950: price=1000 is smart, price=900 is retail
+        trades = [_trade(i, price=1000.0, qty=1.0, side="buy") for i in range(5)] + \
+                 [_trade(i+10, price=900.0, qty=1.0, side="buy") for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=950)
+        # smart_cvd=+5000, retail_cvd=+4500 → score=(5000-4500)/(5000+4500+ε)=500/9500≈0.053 → aligned
+        assert r["signal"] == "aligned"
+
+    def test_both_sell_similar_magnitude_is_aligned(self):
+        # threshold=950: price=1000 is smart, price=900 is retail
+        trades = [_trade(i, price=1000.0, qty=1.0, side="sell") for i in range(5)] + \
+                 [_trade(i+10, price=900.0, qty=1.0, side="sell") for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=950)
+        # smart_cvd=-5000, retail_cvd=-4500 → score=(-5000+4500)/(5000+4500+ε)=-500/9500≈-0.053 → aligned
+        assert r["signal"] == "aligned"
+
+    def test_balanced_is_neutral(self):
+        """Equal smart buy and sell, equal retail → neutral."""
+        trades = [_large_buy(usd=1000), _large_sell(usd=1000),
+                  _small_buy(usd=100), _small_sell(usd=100)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["signal"] == "neutral"
+        assert r["divergence_detected"] is False
+
+    def test_divergence_detected_false_when_neutral(self):
+        r = compute_smart_money_divergence([])
+        assert r["divergence_detected"] is False
+
+    def test_divergence_detected_false_when_aligned(self):
+        # threshold=950: price=1000 is smart, price=900 is retail — both buying → aligned
+        trades = [_trade(i, price=1000.0, qty=1.0, side="buy") for i in range(5)] + \
+                 [_trade(i+10, price=900.0, qty=1.0, side="buy") for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=950)
+        assert r["divergence_detected"] is False
+
+    def test_divergence_detected_true_when_accumulation(self):
+        trades = [_large_buy(usd=50000, ts=i) for i in range(5)] + \
+                 [_small_sell(usd=500, ts=i+10) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["divergence_detected"] is True
+
+    def test_custom_threshold_changes_classification(self):
+        """With threshold=100k, a 50k trade is retail not smart."""
+        t = _large_buy(usd=50000)
+        r = compute_smart_money_divergence([t], threshold_usd=100000)
+        assert r["retail_cvd"] == pytest.approx(50000.0)
+        assert r["smart_cvd"] == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# smart_pct
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSmartPct:
+    def test_smart_pct_all_smart(self):
+        trades = [_large_buy(usd=50000, ts=i) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["smart_pct"] == pytest.approx(1.0)
+
+    def test_smart_pct_all_retail(self):
+        trades = [_small_buy(usd=100, ts=i) for i in range(5)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        assert r["smart_pct"] == pytest.approx(0.0)
+
+    def test_smart_pct_mixed(self):
+        """smart vol=3*50000=150000, retail vol=7*500=3500 → smart_pct=150000/153500."""
+        trades = [_large_buy(usd=50000, ts=i) for i in range(3)] + \
+                 [_small_buy(usd=500, ts=i+10) for i in range(7)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000)
+        expected = 150000.0 / (150000.0 + 3500.0)
+        assert r["smart_pct"] == pytest.approx(expected, rel=1e-4)
+
+    def test_smart_pct_zero_on_empty(self):
+        r = compute_smart_money_divergence([])
+        assert r["smart_pct"] == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bucket aggregation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBuckets:
+    def test_trades_in_same_bucket_aggregated(self):
+        trades = [_large_buy(ts=i*10, usd=50000) for i in range(5)]   # all in bucket 0
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        assert len(r["buckets"]) == 1
+
+    def test_trades_in_different_buckets_separate(self):
+        trades = [_large_buy(ts=0), _large_buy(ts=300), _large_buy(ts=600)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        assert len(r["buckets"]) == 3
+
+    def test_bucket_ts_aligns_to_floor(self):
+        t = _large_buy(ts=350)
+        r = compute_smart_money_divergence([t], threshold_usd=10000, bucket_seconds=300)
+        assert r["buckets"][0]["ts"] == 300.0
+
+    def test_bucket_smart_cvd_correct(self):
+        trades = [_large_buy(ts=0, usd=30000), _large_sell(ts=60, usd=10000)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        assert r["buckets"][0]["smart_cvd"] == pytest.approx(20000.0)
+
+    def test_bucket_retail_cvd_correct(self):
+        trades = [_small_buy(ts=0, usd=300), _small_sell(ts=60, usd=200)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        assert r["buckets"][0]["retail_cvd"] == pytest.approx(100.0)
+
+    def test_buckets_sorted_ascending(self):
+        trades = [_large_buy(ts=600), _large_buy(ts=0), _large_buy(ts=300)]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        ts_vals = [b["ts"] for b in r["buckets"]]
+        assert ts_vals == sorted(ts_vals)
+
+    def test_bucket_smart_and_retail_independent(self):
+        """Each bucket tracks smart and retail separately."""
+        trades = [
+            _large_buy(ts=0, usd=1000),    # smart buy bucket 0 (1000 >= threshold 500)
+            _small_sell(ts=60, usd=200),   # retail sell bucket 0 (200 < threshold 500)
+        ]
+        r = compute_smart_money_divergence(trades, threshold_usd=500, bucket_seconds=300)
+        b = r["buckets"][0]
+        assert b["smart_cvd"] == pytest.approx(1000.0)
+        assert b["retail_cvd"] == pytest.approx(-200.0)
+
+    def test_total_matches_sum_of_buckets(self):
+        import random; random.seed(17)
+        trades = [
+            _trade(i*20, price=random.uniform(100, 60000),
+                   qty=random.uniform(0.1, 5.0),
+                   side=random.choice(["buy","sell"]))
+            for i in range(30)
+        ]
+        r = compute_smart_money_divergence(trades, threshold_usd=10000, bucket_seconds=300)
+        sum_smart  = sum(b["smart_cvd"]  for b in r["buckets"])
+        sum_retail = sum(b["retail_cvd"] for b in r["buckets"])
+        assert r["smart_cvd"]  == pytest.approx(sum_smart,  rel=1e-5)
+        assert r["retail_cvd"] == pytest.approx(sum_retail, rel=1e-5)


### PR DESCRIPTION
## Summary
- Highlights when large trades (>$10k USD, "smart money") go opposite to retail flow direction
- `compute_smart_money_divergence()` pure function classifies trades by `price*qty` vs threshold, computes separate cumulative deltas, and produces a divergence score in `[-1, +1]`
- Signals: **accumulation** (smart buying, retail selling), **distribution** (smart selling, retail buying), **aligned**, **neutral**
- Backend: `/api/smart-money-divergence?symbol=X&window=1800` (single symbol) and `/api/smart-money-divergence/all` (all symbols, sorted by score)
- Frontend: wide card with signal badge, 4 metric tiles (Smart CVD, Retail CVD, Divergence Score, Smart Vol%), and dual-line Chart.js chart (smart=green, retail=orange, independent y-axes)

## Test plan
- [x] 41 unit tests in `tests/test_smart_money_divergence.py` — all passing
- [ ] Verify card renders in dashboard for active symbol
- [ ] Confirm accumulation badge turns green when smart buys dominate
- [ ] Confirm distribution badge turns red when smart sells dominate

🤖 Generated with [Claude Code](https://claude.com/claude-code)