### PR TITLE
feat: add order book recovery speed metric

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -18,6 +18,7 @@ from storage import (
     get_funding_history,
     get_recent_liquidations,
     get_orderbook_snapshots_for_heatmap,
+    get_orderbook_depth_history,
     get_ohlcv,
     insert_alert,
     get_alert_history,
@@ -58,6 +59,7 @@ from metrics import (
     compute_kalman_price,
     compute_ob_pressure_gradient,
     compute_smart_money_divergence,
+    compute_ob_recovery_speed,
 )
 
 router = APIRouter(prefix="/api")
@@ -3374,4 +3376,53 @@ async def smart_money_divergence_all_endpoint(
         "window_seconds": window,
         "threshold_usd": threshold_usd,
         "symbols": results,
+    }
+
+
+@router.get("/ob-recovery-speed")
+async def ob_recovery_speed_endpoint(
+    symbol: str = Query(..., description="Symbol e.g. BTCUSDT"),
+    window: int = Query(default=900, ge=60, le=3600, description="Lookback in seconds (default 15m)"),
+    threshold_usd: float = Query(default=50000.0, ge=1000.0, description="Minimum trade size to consider (USD)"),
+    recovery_pct: float = Query(default=0.8, ge=0.1, le=1.0, description="Fraction of baseline depth required for recovery"),
+    baseline_window: float = Query(default=30.0, ge=5.0, le=120.0, description="Seconds before trade to measure baseline depth"),
+    alert_seconds: float = Query(default=10.0, ge=1.0, le=120.0, description="Recovery time threshold for slow alert"),
+    max_lookforward: float = Query(default=60.0, ge=5.0, le=300.0, description="Max seconds after trade to look for recovery"),
+):
+    """
+    Order book recovery speed: measures how fast the OB refills after large trades.
+
+    For each trade >= threshold_usd:
+    - buy trade → monitors ask side depth recovery
+    - sell trade → monitors bid side depth recovery
+    - baseline = mean depth in baseline_window seconds before trade
+    - recovery_seconds = time until depth returns to recovery_pct * baseline
+    - slow = recovery_seconds > alert_seconds (or not recovered in max_lookforward)
+
+    Returns:
+      events: [{ts, side, trade_usd, baseline_depth, recovery_seconds, recovered, slow}]
+      avg_recovery_seconds, max_recovery_seconds, slow_count, alert, event_count
+    """
+    since = time.time() - window
+    ob_snapshots, trades = await asyncio.gather(
+        get_orderbook_depth_history(symbol=symbol, since=since - baseline_window),
+        get_recent_trades(symbol=symbol, since=since, limit=10000),
+    )
+
+    result = compute_ob_recovery_speed(
+        ob_snapshots,
+        trades,
+        threshold_usd=threshold_usd,
+        recovery_pct=recovery_pct,
+        baseline_window=baseline_window,
+        alert_seconds=alert_seconds,
+        max_lookforward=max_lookforward,
+    )
+
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        "threshold_usd": threshold_usd,
+        **result,
     }

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -2590,7 +2590,6 @@ def compute_smart_money_divergence(
     smart_count = retail_count = 0
     smart_vol_total = retail_vol_total = 0.0
 
-    # {ts_bucket: {smart_buy, smart_sell, retail_buy, retail_sell}}
     bucket_map: dict = {}
 
     for t in trades:
@@ -2598,7 +2597,6 @@ def compute_smart_money_divergence(
         qty   = float(t["qty"])
         val   = price * qty
 
-        # Determine taker direction
         iba = t.get("is_buyer_aggressor")
         if iba is not None:
             is_buy = bool(iba)
@@ -2635,7 +2633,6 @@ def compute_smart_money_divergence(
     total_vol = abs(smart_cvd) + abs(retail_cvd) + 1e-8
     divergence_score = (smart_cvd - retail_cvd) / total_vol
 
-    # Signal classification
     smart_dir  = 1 if smart_cvd  > 0 else (-1 if smart_cvd  < 0 else 0)
     retail_dir = 1 if retail_cvd > 0 else (-1 if retail_cvd < 0 else 0)
     same_dir   = (smart_dir != 0 and retail_dir != 0 and smart_dir == retail_dir)
@@ -2651,11 +2648,9 @@ def compute_smart_money_divergence(
 
     divergence_detected = signal in ("accumulation", "distribution")
 
-    # smart_pct = smart vol / (smart vol + retail vol)
     all_vol = smart_vol_total + retail_vol_total
     smart_pct = (smart_vol_total / all_vol) if all_vol > 0 else 0.0
 
-    # Build bucket series sorted ascending
     buckets = []
     for ts_b in sorted(bucket_map):
         bm = bucket_map[ts_b]
@@ -2675,4 +2670,105 @@ def compute_smart_money_divergence(
         "smart_pct":          round(smart_pct, 6),
         "divergence_detected": divergence_detected,
         "buckets":            buckets,
+    }
+
+
+def compute_ob_recovery_speed(
+    ob_snapshots: List[dict],
+    trades: List[dict],
+    threshold_usd: float = 50000.0,
+    recovery_pct: float = 0.8,
+    baseline_window: float = 30.0,
+    alert_seconds: float = 10.0,
+    max_lookforward: float = 60.0,
+) -> dict:
+    """Measure how fast the order book refills after large trades.
+
+    For each large trade (price*qty >= threshold_usd):
+    - buy (is_buyer_aggressor=True / side="buy")  -> asks consumed -> monitor ask_volume
+    - sell (is_buyer_aggressor=False / side="sell") -> bids consumed -> monitor bid_volume
+    - baseline_depth = mean of consumed-side volume in [trade_ts - baseline_window, trade_ts)
+    - scan ob_snapshots after trade for first snapshot where depth >= recovery_pct * baseline
+    - recovery_seconds = t_recovery - t_trade  (None if not found within max_lookforward)
+
+    Returns:
+        events:               [{ts, side, trade_usd, baseline_depth,
+                                recovery_seconds, recovered, slow}]
+        avg_recovery_seconds: mean of recovered events (0.0 if none)
+        max_recovery_seconds: max of recovered events (0.0 if none)
+        slow_count:           events where slow=True
+        alert:                True if slow_count > 0
+        event_count:          len(events)
+    """
+    obs_sorted = sorted(ob_snapshots, key=lambda x: float(x["ts"]))
+    trd_sorted = sorted(trades,       key=lambda x: float(x["ts"]))
+
+    events = []
+
+    for t in trd_sorted:
+        val = float(t["price"]) * float(t["qty"])
+        if val < threshold_usd:
+            continue
+
+        t_ts = float(t["ts"])
+
+        iba = t.get("is_buyer_aggressor")
+        if iba is not None:
+            is_buy = bool(iba)
+        else:
+            is_buy = (t.get("side") or "").lower() == "buy"
+
+        side = "ask" if is_buy else "bid"
+        depth_key = "ask_volume" if is_buy else "bid_volume"
+
+        pre = [
+            float(s[depth_key])
+            for s in obs_sorted
+            if t_ts - baseline_window <= float(s["ts"]) < t_ts
+        ]
+        baseline = sum(pre) / len(pre) if pre else 0.0
+
+        recovery_seconds = None
+        recovered = False
+        target = recovery_pct * baseline
+
+        if baseline > 0:
+            for s in obs_sorted:
+                s_ts = float(s["ts"])
+                if s_ts <= t_ts:
+                    continue
+                if s_ts - t_ts >= max_lookforward:
+                    break
+                if float(s[depth_key]) >= target:
+                    recovery_seconds = round(s_ts - t_ts, 4)
+                    recovered = True
+                    break
+
+        slow = (not recovered) or (recovery_seconds is not None and recovery_seconds > alert_seconds)
+
+        events.append({
+            "ts":               t_ts,
+            "side":             side,
+            "trade_usd":        round(val, 2),
+            "baseline_depth":   round(baseline, 4),
+            "recovery_seconds": recovery_seconds,
+            "recovered":        recovered,
+            "slow":             slow,
+        })
+
+    recovered_times = [
+        e["recovery_seconds"] for e in events
+        if e["recovered"] and e["recovery_seconds"] is not None
+    ]
+    avg_rec = sum(recovered_times) / len(recovered_times) if recovered_times else 0.0
+    max_rec = max(recovered_times) if recovered_times else 0.0
+    slow_count = sum(1 for e in events if e["slow"])
+
+    return {
+        "events":               events,
+        "avg_recovery_seconds": round(avg_rec, 4),
+        "max_recovery_seconds": round(max_rec, 4),
+        "slow_count":           slow_count,
+        "alert":                slow_count > 0,
+        "event_count":          len(events),
     }

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -624,6 +624,24 @@ async def get_trades_for_cvd(since: float, symbol: str = None) -> List[Dict]:
             return [dict(r) for r in rows]
 
 
+async def get_orderbook_depth_history(
+    symbol: str, since: float, limit: int = 2000
+) -> List[Dict]:
+    """Get orderbook snapshots with bid_volume and ask_volume for recovery analysis."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        q = """
+            SELECT ts, bid_volume, ask_volume, mid_price
+            FROM orderbook_snapshots
+            WHERE ts > ? AND symbol = ?
+            ORDER BY ts ASC
+            LIMIT ?
+        """
+        async with db.execute(q, [since, symbol, limit]) as cur:
+            rows = await cur.fetchall()
+            return [dict(r) for r in rows]
+
+
 async def get_orderbook_snapshots_for_heatmap(
     symbol: str, since: float, sample_interval: int = 10
 ) -> List[Dict]:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1090,6 +1090,15 @@
     <div style="font-size:10px;color:var(--muted);margin-bottom:8px;">smart = trades ≥$10k · retail = trades &lt;$10k · divergence = smart buying while retail sells (or vice versa)</div>
     <div id="smd-metrics" style="display:flex;gap:16px;flex-wrap:wrap;font-size:11px;margin-bottom:10px;"></div>
     <canvas id="chart-smart-money" style="height:130px !important;"></canvas>
+  <!-- OB Recovery Speed -->
+  <div class="card" id="card-ob-recovery">
+    <h2><span class="card-icon">⏱️</span>OB Recovery Speed (15m)
+      <span id="ob-recovery-badge" style="margin-left:8px;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:700;display:none;"></span>
+      <span id="ob-recovery-ts" style="margin-left:auto;font-size:10px;color:var(--muted);font-weight:400;letter-spacing:0;text-transform:none;"></span>
+    </h2>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:8px;">time for OB to refill to 80% depth after large trade (&gt;$50k) · slow = &gt;10s</div>
+    <div id="ob-recovery-metrics" style="display:flex;gap:12px;flex-wrap:wrap;font-size:11px;margin-bottom:10px;"></div>
+    <div id="ob-recovery-list" style="max-height:180px;overflow-y:auto;font-size:11px;"></div>
   </div>
 
   <!-- Whale Trades -->
@@ -3083,6 +3092,7 @@ async function refreshAll() {
   const sym = encodeURIComponent(activeSymbol);
 
   const [cvd, oi, funding, liqs, vp, divg, ltrades, oisp, liqcas, volspike, whales, patternLive, patternHist, oiDelta, tradeRate, spreadData, flowImb, smd] = await Promise.all([
+  const [cvd, oi, funding, liqs, vp, divg, ltrades, oisp, liqcas, volspike, whales, patternLive, patternHist, oiDelta, tradeRate, spreadData, flowImb, obRecovery] = await Promise.all([
     fetchJSON(`/api/cvd/history?window=3600&symbol=${sym}`),
     fetchJSON(`/api/oi/history?limit=300&symbol=${sym}`),
     fetchJSON(`/api/funding/history?limit=200&symbol=${sym}`),
@@ -3101,6 +3111,7 @@ async function refreshAll() {
     fetchJSON(`/api/spread-tracker?window=1800&symbol=${sym}`),
     fetchJSON(`/api/flow-imbalance?window=3600&bucket_size=60&symbol=${sym}`),
     fetchJSON(`/api/smart-money-divergence?window=1800&threshold_usd=10000&bucket_seconds=300&symbol=${sym}`),
+    fetchJSON(`/api/ob-recovery-speed?window=900&threshold_usd=50000&alert_seconds=10&symbol=${sym}`),
   ]);
 
   // CVD + Price dual-axis chart
@@ -3324,6 +3335,50 @@ async function refreshAll() {
           <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:3px;">Smart Vol %</div>
           <div style="color:var(--yellow);font-size:14px;font-weight:700;">${smartPctPct}%</div>
           <div style="color:var(--muted);font-size:9px;">of total volume</div>
+  // ── OB Recovery Speed ────────────────────────────────────────────────────
+  if (obRecovery) {
+    const badgeEl   = document.getElementById('ob-recovery-badge');
+    const tsEl      = document.getElementById('ob-recovery-ts');
+    const metricsEl = document.getElementById('ob-recovery-metrics');
+    const listEl    = document.getElementById('ob-recovery-list');
+
+    if (tsEl) tsEl.textContent = 'last 15m · >$50k trades';
+
+    if (badgeEl) {
+      if (obRecovery.alert) {
+        badgeEl.textContent = 'SLOW RECOVERY';
+        badgeEl.style.background = 'rgba(220,60,60,0.25)';
+        badgeEl.style.color = 'var(--red)';
+        badgeEl.style.display = 'inline-block';
+      } else if (obRecovery.event_count > 0) {
+        badgeEl.textContent = 'HEALTHY';
+        badgeEl.style.background = 'rgba(0,200,120,0.2)';
+        badgeEl.style.color = 'var(--green)';
+        badgeEl.style.display = 'inline-block';
+      } else {
+        badgeEl.style.display = 'none';
+      }
+    }
+
+    if (metricsEl) {
+      const avgCol = obRecovery.avg_recovery_seconds > 10 ? 'var(--red)' : obRecovery.avg_recovery_seconds > 5 ? 'var(--yellow)' : 'var(--green)';
+      const maxCol = obRecovery.max_recovery_seconds > 10 ? 'var(--red)' : 'var(--muted)';
+      metricsEl.innerHTML = [
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:5px 10px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:2px;">Avg Recovery</div>
+          <div style="color:${avgCol};font-size:13px;font-weight:700;">${obRecovery.avg_recovery_seconds.toFixed(1)}s</div>
+        </div>`,
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:5px 10px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:2px;">Max Recovery</div>
+          <div style="color:${maxCol};font-size:13px;font-weight:700;">${obRecovery.max_recovery_seconds.toFixed(1)}s</div>
+        </div>`,
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:5px 10px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:2px;">Events</div>
+          <div style="color:var(--muted);font-size:13px;font-weight:700;">${obRecovery.event_count}</div>
+        </div>`,
+        `<div style="background:rgba(100,100,100,0.15);border:1px solid rgba(150,150,150,0.2);border-radius:6px;padding:5px 10px;text-align:center;">
+          <div style="color:var(--muted);font-size:9px;text-transform:uppercase;margin-bottom:2px;">Slow</div>
+          <div style="color:${obRecovery.slow_count > 0 ? 'var(--red)' : 'var(--muted)'};font-size:13px;font-weight:700;">${obRecovery.slow_count}</div>
         </div>`,
       ].join('');
     }
@@ -3334,6 +3389,22 @@ async function refreshAll() {
       chartSmartMoney.data.datasets[0].data = buckets.map(b => b.smart_cvd);
       chartSmartMoney.data.datasets[1].data = buckets.map(b => b.retail_cvd);
       chartSmartMoney.update('none');
+    if (listEl && obRecovery.events?.length) {
+      listEl.innerHTML = obRecovery.events.slice().reverse().map(e => {
+        const sideCol = e.side === 'ask' ? 'var(--green)' : 'var(--red)';
+        const sideLabel = e.side === 'ask' ? 'BUY' : 'SELL';
+        const recCol = !e.recovered ? 'var(--red)' : e.slow ? 'var(--yellow)' : 'var(--green)';
+        const recLabel = !e.recovered ? 'no refill' : `${e.recovery_seconds.toFixed(1)}s`;
+        return `<div style="display:flex;gap:10px;align-items:center;padding:3px 0;border-bottom:1px solid var(--border);">
+          <span style="color:${sideCol};min-width:28px;font-size:10px;font-weight:700;">${sideLabel}</span>
+          <span style="color:var(--yellow);min-width:60px;">$${(e.trade_usd/1000).toFixed(0)}k</span>
+          <span style="color:${recCol};min-width:55px;font-weight:${e.slow ? '700' : '400'};">${recLabel}</span>
+          <span style="color:var(--muted);font-size:10px;">${fmtTs(e.ts)}</span>
+          ${e.slow ? '<span style="color:var(--red);font-size:10px;font-weight:700;">⚠ SLOW</span>' : ''}
+        </div>`;
+      }).join('') || '<div style="color:var(--muted);padding:8px;">No large trades in last 15m</div>';
+    } else if (listEl) {
+      listEl.innerHTML = '<div style="color:var(--muted);padding:8px;">No large trades in last 15m</div>';
     }
   }
 

--- a/tests/test_ob_recovery_speed.py
+++ b/tests/test_ob_recovery_speed.py
@@ -1,0 +1,460 @@
+"""
+TDD tests for order book recovery speed metric.
+
+Spec:
+  compute_ob_recovery_speed(
+      ob_snapshots,          # [{ts, bid_volume, ask_volume}]
+      trades,                # [{ts, price, qty, side, [is_buyer_aggressor]}]
+      threshold_usd=50000,   # minimum trade value to consider
+      recovery_pct=0.8,      # depth must recover to 80% of baseline
+      baseline_window=30.0,  # seconds before trade to measure baseline
+      alert_seconds=10.0,    # recovery > this → slow
+      max_lookforward=60.0,  # cap on recovery search window
+  )
+
+  For each large trade (price*qty >= threshold_usd):
+    - buy (side="buy" / is_buyer_aggressor=True)  → asks consumed → monitor ask_volume
+    - sell (side="sell" / is_buyer_aggressor=False) → bids consumed → monitor bid_volume
+    - baseline_depth = mean depth of consumed-side volume in [trade_ts - baseline_window, trade_ts)
+    - scan ob_snapshots after trade: first ts where depth >= recovery_pct * baseline
+    - recovery_seconds = t_recovery - t_trade  (None if not found in max_lookforward)
+
+  Returns:
+    events:               [{ts, side, trade_usd, baseline_depth, recovery_seconds, recovered, slow}]
+    avg_recovery_seconds: mean of recovered events (0.0 if none)
+    max_recovery_seconds: max of recovered events (0.0 if none)
+    slow_count:           events where slow=True
+    alert:                bool — True if slow_count > 0
+    event_count:          total large-trade events found
+"""
+import sys, os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+from metrics import compute_ob_recovery_speed  # noqa: E402
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _ob(ts, bid_vol, ask_vol):
+    return {"ts": float(ts), "bid_volume": float(bid_vol), "ask_volume": float(ask_vol)}
+
+def _trade(ts, price, qty, side="buy", is_buyer_aggressor=None):
+    d = {"ts": float(ts), "price": float(price), "qty": float(qty), "side": side}
+    if is_buyer_aggressor is not None:
+        d["is_buyer_aggressor"] = int(is_buyer_aggressor)
+    return d
+
+def _large_buy(ts, usd=100000):
+    return _trade(ts, price=float(usd), qty=1.0, side="buy")
+
+def _large_sell(ts, usd=100000):
+    return _trade(ts, price=float(usd), qty=1.0, side="sell")
+
+def _small_buy(ts, usd=1000):
+    return _trade(ts, price=float(usd), qty=1.0, side="buy")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Structure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStructure:
+    def test_empty_returns_valid_dict(self):
+        r = compute_ob_recovery_speed([], [])
+        assert isinstance(r, dict)
+
+    def test_result_has_required_fields(self):
+        r = compute_ob_recovery_speed([], [])
+        for f in ("events", "avg_recovery_seconds", "max_recovery_seconds",
+                  "slow_count", "alert", "event_count"):
+            assert f in r, f"missing: {f}"
+
+    def test_empty_gives_zero_counts(self):
+        r = compute_ob_recovery_speed([], [])
+        assert r["event_count"] == 0
+        assert r["slow_count"] == 0
+        assert r["alert"] is False
+        assert r["events"] == []
+
+    def test_event_has_required_fields(self):
+        obs = [_ob(0, 500, 500), _ob(5, 500, 200), _ob(15, 500, 450)]
+        trd = [_large_buy(ts=3)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, alert_seconds=10,
+                                       max_lookforward=60)
+        assert r["event_count"] >= 1
+        e = r["events"][0]
+        for f in ("ts", "side", "trade_usd", "baseline_depth",
+                  "recovery_seconds", "recovered", "slow"):
+            assert f in e, f"missing event field: {f}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Trade filtering
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTradeFiltering:
+    def test_small_trade_not_an_event(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_small_buy(ts=1, usd=1000)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 0
+
+    def test_large_trade_is_an_event(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=1, usd=100000)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 1
+
+    def test_exactly_at_threshold_is_event(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_trade(ts=1, price=50000.0, qty=1.0, side="buy")]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 1
+
+    def test_just_below_threshold_not_event(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_trade(ts=1, price=49999.0, qty=1.0, side="buy")]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 0
+
+    def test_trade_usd_uses_price_times_qty(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_trade(ts=1, price=500.0, qty=120.0, side="buy")]  # 60000 >= 50000
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 1
+        assert r["events"][0]["trade_usd"] == pytest.approx(60000.0)
+
+    def test_multiple_large_trades_all_counted(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=1), _large_sell(ts=2), _large_buy(ts=3)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Side determination
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSideDetermination:
+    def test_buy_trade_monitors_ask_side(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=1)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["events"][0]["side"] == "ask"
+
+    def test_sell_trade_monitors_bid_side(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_sell(ts=1)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["events"][0]["side"] == "bid"
+
+    def test_is_buyer_aggressor_true_monitors_ask(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_trade(ts=1, price=100000, qty=1.0, side="sell", is_buyer_aggressor=True)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["events"][0]["side"] == "ask"
+
+    def test_is_buyer_aggressor_false_monitors_bid(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_trade(ts=1, price=100000, qty=1.0, side="buy", is_buyer_aggressor=False)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["events"][0]["side"] == "bid"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Baseline depth
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBaselineDepth:
+    def test_baseline_is_mean_of_pre_trade_snapshots(self):
+        """Baseline = mean ask_volume in [trade_ts - baseline_window, trade_ts)."""
+        obs = [
+            _ob(0,  500, 400),   # 30s before trade → in window
+            _ob(10, 500, 600),   # 20s before trade → in window
+            _ob(20, 500, 500),   # 10s before trade → in window
+            # trade at ts=30
+        ]
+        trd = [_large_buy(ts=30)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=30, max_lookforward=5)
+        # baseline = mean(400, 600, 500) = 500
+        assert r["events"][0]["baseline_depth"] == pytest.approx(500.0)
+
+    def test_baseline_excludes_post_trade_snapshots(self):
+        """Snapshots at or after trade_ts not included in baseline."""
+        obs = [
+            _ob(0,  500, 600),  # in window
+            _ob(30, 500, 100),  # AT trade ts — should not be included in baseline
+        ]
+        trd = [_large_buy(ts=30)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=60, max_lookforward=5)
+        # baseline should only use ts=0 snapshot
+        assert r["events"][0]["baseline_depth"] == pytest.approx(600.0)
+
+    def test_baseline_excludes_snapshots_outside_window(self):
+        """Snapshots older than baseline_window not included."""
+        obs = [
+            _ob(0,  500, 999),  # 50s before trade — outside 30s window
+            _ob(20, 500, 400),  # 10s before trade — inside window
+        ]
+        trd = [_large_buy(ts=50)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=30, max_lookforward=5)
+        assert r["events"][0]["baseline_depth"] == pytest.approx(400.0)
+
+    def test_no_pre_trade_snapshots_baseline_is_zero(self):
+        """No snapshots before trade → baseline = 0 → no recovery possible."""
+        obs = [_ob(100, 500, 500)]   # after trade
+        trd = [_large_buy(ts=50)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=30, max_lookforward=60)
+        assert r["events"][0]["baseline_depth"] == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Recovery detection
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestRecoveryDetection:
+    def test_fast_recovery_detected(self):
+        """Ask depth drops after buy trade, recovers within a few seconds."""
+        obs = [
+            _ob(0,  500, 500),   # baseline window
+            _ob(10, 500, 500),
+            # trade at ts=15
+            _ob(16, 500, 50),    # depth drops right after trade
+            _ob(20, 500, 450),   # recovers to 90% (>80%)
+        ]
+        trd = [_large_buy(ts=15)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=20, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is True
+        assert e["recovery_seconds"] == pytest.approx(5.0)  # ts=20 - ts=15
+
+    def test_slow_recovery_flagged(self):
+        """Recovery takes 25s — exceeds alert_seconds=10."""
+        obs = [
+            _ob(0,  500, 500),
+            # trade at ts=5
+            _ob(6,  500, 50),    # drops
+            _ob(30, 500, 450),   # recovers at ts=30 → 25s after trade
+        ]
+        trd = [_large_buy(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is True
+        assert e["recovery_seconds"] == pytest.approx(25.0)
+        assert e["slow"] is True
+        assert r["alert"] is True
+
+    def test_fast_recovery_not_slow(self):
+        """Recovery in 3s — below alert_seconds=10."""
+        obs = [
+            _ob(0,  500, 500),
+            # trade at ts=5
+            _ob(8,  500, 450),   # 3s after trade, recovered 90%
+        ]
+        trd = [_large_buy(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is True
+        assert e["slow"] is False
+
+    def test_no_recovery_in_window_not_recovered(self):
+        """Depth never refills within max_lookforward."""
+        obs = [
+            _ob(0,  500, 500),
+            # trade at ts=10
+            _ob(11, 500, 50),    # drops
+            _ob(20, 500, 100),   # stays low
+            _ob(70, 500, 450),   # recovers but AFTER max_lookforward=60
+        ]
+        trd = [_large_buy(ts=10)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=15, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is False
+        assert e["recovery_seconds"] is None
+        assert e["slow"] is True
+
+    def test_recovery_pct_threshold_respected(self):
+        """Depth must reach recovery_pct * baseline to count as recovered."""
+        obs = [
+            _ob(0,  500, 1000),
+            # trade at ts=5, baseline=1000
+            _ob(10, 500, 799),   # 79.9% — below 80% threshold
+            _ob(15, 500, 801),   # 80.1% — above threshold → recovered
+        ]
+        trd = [_large_buy(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is True
+        assert e["recovery_seconds"] == pytest.approx(10.0)  # ts=15 - ts=5
+
+    def test_bid_side_recovery_for_sell_trade(self):
+        """Sell trade consumes bid side — bid_volume tracked for recovery."""
+        obs = [
+            _ob(0,  500, 500),
+            # trade at ts=5
+            _ob(6,  50,  500),   # bids drop
+            _ob(15, 450, 500),   # bids recover
+        ]
+        trd = [_large_sell(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        e = r["events"][0]
+        assert e["side"] == "bid"
+        assert e["recovered"] is True
+        assert e["recovery_seconds"] == pytest.approx(10.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Aggregates
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestAggregates:
+    def test_avg_recovery_mean_of_recovered_events(self):
+        """Two events: 5s and 15s recovery → avg = 10s."""
+        obs = [
+            _ob(0,  500, 500),   # baseline for trade1 (ts=10, window=[−5,10))
+            _ob(15, 500, 450),   # +5s after trade1 at ts=10 → recovered
+            _ob(40, 500, 500),   # baseline for trade2 (ts=50, window=[35,50))
+            _ob(65, 500, 450),   # +15s after trade2 at ts=50 → recovered
+        ]
+        trd = [_large_buy(ts=10), _large_buy(ts=50)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=15, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        # Both should be recovered
+        recovered = [e for e in r["events"] if e["recovered"]]
+        assert len(recovered) == 2
+        assert r["avg_recovery_seconds"] == pytest.approx(10.0)
+
+    def test_max_recovery_is_max_across_events(self):
+        obs = [
+            _ob(0,  500, 500),   # baseline for trade1
+            _ob(15, 500, 450),   # trade1 at ts=10 → 5s
+            _ob(40, 500, 500),   # baseline for trade2
+            _ob(65, 500, 450),   # trade2 at ts=50 → 15s
+        ]
+        trd = [_large_buy(ts=10), _large_buy(ts=50)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=15, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        assert r["max_recovery_seconds"] == pytest.approx(15.0)
+
+    def test_avg_recovery_zero_when_none_recovered(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=100)]   # no post-trade snapshots
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=110, max_lookforward=60)
+        assert r["avg_recovery_seconds"] == 0.0
+
+    def test_max_recovery_zero_when_none_recovered(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=100)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=110, max_lookforward=60)
+        assert r["max_recovery_seconds"] == 0.0
+
+    def test_slow_count_correct(self):
+        """2 slow events, 1 fast."""
+        obs = [
+            _ob(0,   500, 500),
+            _ob(20,  500, 450),   # trade at ts=5  → 15s, slow
+            _ob(7,   500, 450),   # trade at ts=5, fast (ts=7 → 2s)
+            _ob(120, 500, 450),   # trade at ts=100 → 20s, slow
+        ]
+        trd = [_large_buy(ts=5), _large_buy(ts=100)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        # ts=5: first snapshot after trade is ts=7 (2s → fast), then ts=20 (15s)
+        # Since ts=7 has 450 >= 0.8*500=400, recovery at 2s → not slow
+        # ts=100: next snapshot ts=120 (20s → slow)
+        assert r["slow_count"] >= 1
+
+    def test_alert_false_when_no_slow_events(self):
+        obs = [_ob(0, 500, 500), _ob(6, 500, 450)]
+        trd = [_large_buy(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        assert r["alert"] is False
+
+    def test_alert_true_when_slow_events_exist(self):
+        obs = [_ob(0, 500, 500), _ob(30, 500, 450)]
+        trd = [_large_buy(ts=5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, recovery_pct=0.8,
+                                       alert_seconds=10, max_lookforward=60)
+        assert r["alert"] is True
+
+    def test_event_count_matches_events_list(self):
+        obs = [_ob(0, 500, 500)]
+        trd = [_large_buy(ts=1), _large_sell(ts=2), _large_buy(ts=3)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000)
+        assert r["event_count"] == len(r["events"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Edge cases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestEdgeCases:
+    def test_no_ob_snapshots_no_recovery(self):
+        trd = [_large_buy(ts=1)]
+        r = compute_ob_recovery_speed([], trd, threshold_usd=50000)
+        assert r["event_count"] == 1
+        assert r["events"][0]["recovered"] is False
+
+    def test_ob_snapshots_but_no_trades(self):
+        obs = [_ob(0, 500, 500), _ob(10, 500, 500)]
+        r = compute_ob_recovery_speed(obs, [], threshold_usd=50000)
+        assert r["event_count"] == 0
+
+    def test_unsorted_inputs_handled(self):
+        """Function must sort both inputs by ts."""
+        obs = [_ob(20, 500, 450), _ob(0, 500, 500)]
+        trd = [_large_buy(ts=15)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=20, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        e = r["events"][0]
+        assert e["baseline_depth"] == pytest.approx(500.0)
+        assert e["recovered"] is True
+
+    def test_zero_baseline_no_crash(self):
+        """If baseline_depth=0 (no pre-trade obs), function does not raise."""
+        obs = [_ob(100, 500, 500)]
+        trd = [_large_buy(ts=50)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=10, max_lookforward=60)
+        assert r["events"][0]["recovered"] is False
+
+    def test_recovery_immediately_at_next_snapshot_zero_seconds(self):
+        """If the very next snapshot is already recovered, recovery_seconds > 0."""
+        obs = [
+            _ob(0, 500, 500),
+            _ob(1, 500, 450),   # 1s after trade, already recovered
+        ]
+        trd = [_large_buy(ts=0.5)]
+        r = compute_ob_recovery_speed(obs, trd, threshold_usd=50000,
+                                       baseline_window=1, recovery_pct=0.8,
+                                       alert_seconds=30, max_lookforward=60)
+        e = r["events"][0]
+        assert e["recovered"] is True
+        assert e["recovery_seconds"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Track time for order book to refill after large trade consumption (>=$50k by default)
- Buy trade hits asks → monitor ask depth recovery; sell trade hits bids → monitor bid depth recovery
- Baseline depth = mean OB depth in 30s window before each large trade
- Recovery detected when depth returns to ≥80% of baseline within 60s
- Alert fires when any recovery takes >10s or fails to complete in the lookforward window

## Implementation
- `compute_ob_recovery_speed()` pure function in `backend/metrics.py` — fully testable without DB
- `get_orderbook_depth_history()` new storage query selecting `bid_volume`/`ask_volume` columns
- `GET /api/ob-recovery-speed?symbol=X&window=900` endpoint with configurable thresholds
- Frontend card: alert badge (SLOW RECOVERY / HEALTHY), metric tiles (avg/max/event count/slow count), per-event list with recovery time and ⚠ SLOW indicator

## Test plan
- [x] 37 unit tests in `tests/test_ob_recovery_speed.py` — all passing
- [ ] Confirm card renders for active symbol
- [ ] Trigger slow recovery by observing after a whale trade
- [ ] Verify SLOW RECOVERY badge appears when recovery exceeds alert threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)