### PR TITLE
feat: add market microstructure score

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -68,6 +68,7 @@ from metrics import (
     compute_tick_imbalance_bars,
     compute_volume_bars,
     compute_price_ladder,
+    compute_market_microstructure_score,
 )
 
 router = APIRouter(prefix="/api")
@@ -4424,3 +4425,66 @@ async def price_ladder_endpoint(
         "window_seconds": window,
         **result,
     }
+@router.get("/market-microstructure")
+async def market_microstructure_endpoint(
+    symbol: str = Query(...),
+    window: int = Query(300),
+):
+    """Composite 0-100 market microstructure quality score.
+
+    Aggregates spread, order book depth, trade rate, and price noise into
+    a single score with letter grade (A–F) and component breakdown.
+    """
+    spread_stats, ob_rows, trades, kalman = await asyncio.gather(
+        get_spread_stats(symbol, window=window),
+        get_latest_orderbook(symbol=symbol),
+        get_recent_trades(symbol=symbol, since=time.time() - window, limit=5000),
+        compute_kalman_price(symbol=symbol, window_seconds=window),
+    )
+
+    # ── spread ────────────────────────────────────────────────────────────────
+    spread_bps = float(spread_stats.get("current_bps") or 0.0)
+
+    # ── depth (bid+ask qty * mid_price → USD) ─────────────────────────────────
+    if ob_rows:
+        row = ob_rows[0]
+        bid_vol = float(row.get("bid_volume") or 0.0)
+        ask_vol = float(row.get("ask_volume") or 0.0)
+        mid = float(row.get("mid_price") or 1.0)
+        depth_usd = (bid_vol + ask_vol) * mid
+    else:
+        depth_usd = 0.0
+
+    # ── trade rate (trades/s over actual span) ────────────────────────────────
+    if len(trades) >= 2:
+        # get_recent_trades returns DESC order: trades[0] is most recent
+        span = max(float(trades[0]["ts"]) - float(trades[-1]["ts"]), 1.0)
+        trade_rate = len(trades) / span
+    elif len(trades) == 1:
+        trade_rate = 1.0 / window
+    else:
+        trade_rate = 0.0
+
+    # ── noise (Kalman deviation_pct → 0-1, cap at 1.0% = "terrible") ─────────
+    raw_noise_pct = abs(float(kalman.get("deviation_pct") or 0.0))
+    noise_ratio = min(1.0, raw_noise_pct / 1.0)
+
+    result = compute_market_microstructure_score(
+        spread_bps=spread_bps,
+        depth_usd=depth_usd,
+        trade_rate=trade_rate,
+        noise_ratio=noise_ratio,
+    )
+
+    return JSONResponse({
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        "inputs": {
+            "spread_bps": round(spread_bps, 4),
+            "depth_usd": round(depth_usd, 2),
+            "trade_rate": round(trade_rate, 4),
+            "noise_ratio": round(noise_ratio, 6),
+        },
+        **result,
+    })

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -3589,3 +3589,100 @@ def compute_price_ladder(snapshots, num_levels=20, bin_size=None, wall_sigma=1.5
         "snapshot_count": n_snaps,
         "bin_size":       bin_size,
     }
+
+
+def compute_market_microstructure_score(
+    spread_bps: float,
+    depth_usd: float,
+    trade_rate: float,
+    noise_ratio: float,
+    *,
+    min_spread_bps: float = 0.5,
+    max_spread_bps: float = 50.0,
+    min_depth_usd: float = 10_000.0,
+    max_depth_usd: float = 5_000_000.0,
+    min_trade_rate: float = 0.01,
+    max_trade_rate: float = 10.0,
+    weights: dict = None,
+) -> dict:
+    """Composite 0-100 market microstructure quality score.
+
+    Components (each 0-100, higher = better quality):
+    - spread:     bid-ask spread in bps (lower is better)  — linear
+    - depth:      total OB depth in USD (higher is better) — log-linear
+    - trade_rate: trades per second     (higher is better) — log-linear
+    - noise:      noise_ratio 0-1       (lower is better)  — linear, inverted
+
+    Default weights: spread=0.35, depth=0.30, trade_rate=0.20, noise=0.15
+
+    Grade bands: A≥80, B≥60, C≥40, D≥20, F<20
+    """
+    import math
+
+    if weights is None:
+        weights = {"spread": 0.35, "depth": 0.30, "trade_rate": 0.20, "noise": 0.15}
+
+    def _clamp(v: float) -> float:
+        return max(0.0, min(100.0, v))
+
+    # ── spread score (lower = better, linear) ─────────────────────────────────
+    spread_range = max_spread_bps - min_spread_bps
+    spread_score = _clamp(100.0 * (max_spread_bps - spread_bps) / spread_range)
+
+    # ── depth score (higher = better, log-linear) ─────────────────────────────
+    if depth_usd <= 0:
+        depth_score = 0.0
+    else:
+        log_range = math.log(max_depth_usd / min_depth_usd)
+        depth_score = _clamp(
+            100.0 * math.log(max(depth_usd, min_depth_usd) / min_depth_usd) / log_range
+        )
+
+    # ── trade rate score (higher = better, log-linear) ────────────────────────
+    if trade_rate <= 0:
+        trade_rate_score = 0.0
+    else:
+        log_range = math.log(max_trade_rate / min_trade_rate)
+        trade_rate_score = _clamp(
+            100.0 * math.log(max(trade_rate, min_trade_rate) / min_trade_rate) / log_range
+        )
+
+    # ── noise score (lower = better, linear inverted) ─────────────────────────
+    noise_score = _clamp(100.0 * (1.0 - noise_ratio))
+
+    # ── composite ─────────────────────────────────────────────────────────────
+    total_weight = sum(weights.values())
+    composite = (
+        weights["spread"]     * spread_score
+        + weights["depth"]    * depth_score
+        + weights["trade_rate"] * trade_rate_score
+        + weights["noise"]    * noise_score
+    ) / total_weight
+    composite = round(_clamp(composite), 2)
+
+    # ── grade / label ──────────────────────────────────────────────────────────
+    if composite >= 80:
+        grade, label = "A", "excellent"
+    elif composite >= 60:
+        grade, label = "B", "good"
+    elif composite >= 40:
+        grade, label = "C", "fair"
+    elif composite >= 20:
+        grade, label = "D", "poor"
+    else:
+        grade, label = "F", "very poor"
+
+    norm_weights = {k: v / total_weight for k, v in weights.items()}
+
+    return {
+        "score": composite,
+        "grade": grade,
+        "label": label,
+        "components": {
+            "spread":     {"score": round(spread_score,      2), "value": spread_bps,  "weight": norm_weights["spread"]},
+            "depth":      {"score": round(depth_score,       2), "value": depth_usd,   "weight": norm_weights["depth"]},
+            "trade_rate": {"score": round(trade_rate_score,  2), "value": trade_rate,  "weight": norm_weights["trade_rate"]},
+            "noise":      {"score": round(noise_score,       2), "value": noise_ratio, "weight": norm_weights["noise"]},
+        },
+        "weights": norm_weights,
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -665,6 +665,73 @@ async function renderPhase() {
   }
 }
 
+// ── Render: Microstructure Score ──────────────────────────────────────────────
+function _compColor(score) {
+  if (score == null) return 'var(--muted)';
+  return score >= 80 ? 'var(--green)'
+       : score >= 60 ? '#64b4ff'
+       : score >= 40 ? 'var(--yellow)'
+       : 'var(--red)';
+}
+
+async function renderMicrostructure() {
+  const sym = encodeURIComponent(activeSymbol);
+  const data = await apiFetch(`/market-microstructure?symbol=${sym}&window=300`);
+  if (!data) return;
+
+  const badge = document.getElementById('microstructure-badge');
+  if (badge) {
+    badge.textContent = data.grade + ' · ' + (data.label || '');
+    badge.className = 'card-badge '
+      + (data.grade === 'A' ? 'badge-green'
+       : data.grade === 'B' ? 'badge-blue'
+       : data.grade === 'C' ? 'badge-yellow'
+       : 'badge-red');
+    badge.style.display = 'inline-block';
+  }
+
+  const el = document.getElementById('microstructure-content');
+  if (!el) return;
+
+  const c   = data.components || {};
+  const scoreColor = _compColor(data.score);
+
+  const spreadVal    = c.spread?.value     != null ? c.spread.value.toFixed(1) + ' bps' : '—';
+  const depthVal     = c.depth?.value      != null ? '$' + fmtK(c.depth.value)          : '—';
+  const rateVal      = c.trade_rate?.value != null ? c.trade_rate.value.toFixed(2) + '/s' : '—';
+  const noiseVal     = c.noise?.value      != null ? (c.noise.value * 100).toFixed(2) + '%' : '—';
+
+  el.innerHTML = `
+    <div class="phase-metrics">
+      <div class="metric-box">
+        <div class="metric-label">Score</div>
+        <div class="metric-value" style="color:${scoreColor};font-size:22px">${data.score}</div>
+        <div class="metric-label" style="color:${scoreColor}">${data.label || ''}</div>
+      </div>
+      <div class="metric-box">
+        <div class="metric-label">Spread</div>
+        <div class="metric-value" style="color:${_compColor(c.spread?.score)}">${c.spread?.score ?? '—'}</div>
+        <div class="metric-label">${spreadVal}</div>
+      </div>
+      <div class="metric-box">
+        <div class="metric-label">Depth</div>
+        <div class="metric-value" style="color:${_compColor(c.depth?.score)}">${c.depth?.score ?? '—'}</div>
+        <div class="metric-label">${depthVal}</div>
+      </div>
+      <div class="metric-box">
+        <div class="metric-label">Trade Rate</div>
+        <div class="metric-value" style="color:${_compColor(c.trade_rate?.score)}">${c.trade_rate?.score ?? '—'}</div>
+        <div class="metric-label">${rateVal}</div>
+      </div>
+      <div class="metric-box">
+        <div class="metric-label">Noise</div>
+        <div class="metric-value" style="color:${_compColor(c.noise?.score)}">${c.noise?.score ?? '—'}</div>
+        <div class="metric-label">${noiseVal}</div>
+      </div>
+    </div>
+  `;
+}
+
 // ── WebSocket: Alerts ─────────────────────────────────────────────────────────
 function connectAlerts() {
   if (wsAlerts) {
@@ -755,6 +822,7 @@ async function refresh() {
     renderTradeTape(),
     renderVolumeImbalance(),
     renderPhase(),
+    renderMicrostructure(),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,6 +131,18 @@
     </div>
   </section>
 
+  <!-- Market Microstructure Score -->
+  <section class="card" id="card-microstructure">
+    <div class="card-header">
+      <span class="card-title">Microstructure Quality</span>
+      <span id="microstructure-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">spread · depth · trade rate · noise</span>
+    </div>
+    <div id="microstructure-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
 </main>
 
 <script src="app.js"></script>

--- a/tests/test_microstructure_score.py
+++ b/tests/test_microstructure_score.py
@@ -1,0 +1,332 @@
+"""Tests for compute_market_microstructure_score — composite 0-100 market quality score."""
+import math
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+from metrics import compute_market_microstructure_score
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+PERFECT = dict(spread_bps=0.5, depth_usd=5_000_000.0, trade_rate=10.0, noise_ratio=0.0)
+TERRIBLE = dict(spread_bps=50.0, depth_usd=0.0, trade_rate=0.0, noise_ratio=1.0)
+# All components at their geometric / arithmetic midpoint → each score = 50.0
+MIDPOINT = dict(
+    spread_bps=25.25,                              # arithmetic midpoint of 0.5..50.0
+    depth_usd=math.sqrt(10_000.0 * 5_000_000.0),  # geometric mean
+    trade_rate=math.sqrt(0.01 * 10.0),             # geometric mean
+    noise_ratio=0.5,                               # arithmetic midpoint of 0..1
+)
+
+
+def _score(**kwargs):
+    return compute_market_microstructure_score(**kwargs)
+
+
+# ── TestStructure ─────────────────────────────────────────────────────────────
+
+class TestStructure:
+    def test_returns_dict(self):
+        assert isinstance(_score(**PERFECT), dict)
+
+    def test_has_score_key(self):
+        assert "score" in _score(**PERFECT)
+
+    def test_has_grade_key(self):
+        assert "grade" in _score(**PERFECT)
+
+    def test_has_label_key(self):
+        assert "label" in _score(**PERFECT)
+
+    def test_has_components_key(self):
+        assert "components" in _score(**PERFECT)
+
+    def test_has_weights_key(self):
+        assert "weights" in _score(**PERFECT)
+
+    def test_score_is_float(self):
+        assert isinstance(_score(**PERFECT)["score"], float)
+
+    def test_score_range_0_to_100_perfect(self):
+        r = _score(**PERFECT)
+        assert 0.0 <= r["score"] <= 100.0
+
+    def test_score_range_0_to_100_terrible(self):
+        r = _score(**TERRIBLE)
+        assert 0.0 <= r["score"] <= 100.0
+
+    def test_components_has_four_keys(self):
+        c = _score(**PERFECT)["components"]
+        assert set(c.keys()) == {"spread", "depth", "trade_rate", "noise"}
+
+    def test_each_component_has_score_value_weight(self):
+        c = _score(**PERFECT)["components"]
+        for name in ("spread", "depth", "trade_rate", "noise"):
+            assert "score" in c[name], f"{name} missing 'score'"
+            assert "value" in c[name], f"{name} missing 'value'"
+            assert "weight" in c[name], f"{name} missing 'weight'"
+
+    def test_component_scores_in_0_100_range(self):
+        c = _score(**MIDPOINT)["components"]
+        for name in ("spread", "depth", "trade_rate", "noise"):
+            assert 0.0 <= c[name]["score"] <= 100.0
+
+    def test_weights_sum_to_1(self):
+        w = _score(**PERFECT)["weights"]
+        assert abs(sum(w.values()) - 1.0) < 1e-9
+
+    def test_grade_is_string(self):
+        assert isinstance(_score(**PERFECT)["grade"], str)
+
+    def test_label_is_string(self):
+        assert isinstance(_score(**PERFECT)["label"], str)
+
+
+# ── TestSpreadScore ───────────────────────────────────────────────────────────
+
+class TestSpreadScore:
+    def test_min_spread_gives_100(self):
+        r = _score(spread_bps=0.5, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["spread"]["score"] == 100.0
+
+    def test_max_spread_gives_0(self):
+        r = _score(spread_bps=50.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["spread"]["score"] == 0.0
+
+    def test_spread_midpoint_gives_50(self):
+        r = _score(spread_bps=25.25, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert abs(r["components"]["spread"]["score"] - 50.0) < 1e-6
+
+    def test_spread_below_min_clamped_to_100(self):
+        r = _score(spread_bps=0.1, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["spread"]["score"] == 100.0
+
+    def test_spread_above_max_clamped_to_0(self):
+        r = _score(spread_bps=100.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["spread"]["score"] == 0.0
+
+    def test_spread_value_stored_in_component(self):
+        r = _score(spread_bps=7.5, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["spread"]["value"] == 7.5
+
+
+# ── TestDepthScore ────────────────────────────────────────────────────────────
+
+class TestDepthScore:
+    def test_zero_depth_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=0.0, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["depth"]["score"] == 0.0
+
+    def test_min_depth_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=10_000.0, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["depth"]["score"] == 0.0
+
+    def test_max_depth_gives_100(self):
+        r = _score(spread_bps=5.0, depth_usd=5_000_000.0, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["depth"]["score"] == 100.0
+
+    def test_geometric_mean_depth_gives_50(self):
+        depth = math.sqrt(10_000.0 * 5_000_000.0)
+        r = _score(spread_bps=5.0, depth_usd=depth, trade_rate=1.0, noise_ratio=0.0)
+        assert abs(r["components"]["depth"]["score"] - 50.0) < 1e-6
+
+    def test_depth_below_min_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=5_000.0, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["depth"]["score"] == 0.0
+
+    def test_depth_above_max_clamped_to_100(self):
+        r = _score(spread_bps=5.0, depth_usd=10_000_000.0, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["depth"]["score"] == 100.0
+
+
+# ── TestTradeRateScore ────────────────────────────────────────────────────────
+
+class TestTradeRateScore:
+    def test_zero_rate_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=0.0, noise_ratio=0.0)
+        assert r["components"]["trade_rate"]["score"] == 0.0
+
+    def test_min_rate_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=0.01, noise_ratio=0.0)
+        assert r["components"]["trade_rate"]["score"] == 0.0
+
+    def test_max_rate_gives_100(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=10.0, noise_ratio=0.0)
+        assert r["components"]["trade_rate"]["score"] == 100.0
+
+    def test_geometric_mean_rate_gives_50(self):
+        rate = math.sqrt(0.01 * 10.0)
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=rate, noise_ratio=0.0)
+        assert abs(r["components"]["trade_rate"]["score"] - 50.0) < 1e-6
+
+    def test_rate_below_min_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=0.005, noise_ratio=0.0)
+        assert r["components"]["trade_rate"]["score"] == 0.0
+
+    def test_rate_above_max_clamped_to_100(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=100.0, noise_ratio=0.0)
+        assert r["components"]["trade_rate"]["score"] == 100.0
+
+
+# ── TestNoiseScore ────────────────────────────────────────────────────────────
+
+class TestNoiseScore:
+    def test_zero_noise_gives_100(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.0)
+        assert r["components"]["noise"]["score"] == 100.0
+
+    def test_max_noise_gives_0(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=1.0)
+        assert r["components"]["noise"]["score"] == 0.0
+
+    def test_noise_midpoint_gives_50(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.5)
+        assert abs(r["components"]["noise"]["score"] - 50.0) < 1e-6
+
+    def test_noise_above_1_clamped_to_0(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=2.0)
+        assert r["components"]["noise"]["score"] == 0.0
+
+    def test_noise_below_0_clamped_to_100(self):
+        r = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=-0.5)
+        assert r["components"]["noise"]["score"] == 100.0
+
+
+# ── TestCompositeScore ────────────────────────────────────────────────────────
+
+class TestCompositeScore:
+    def test_all_perfect_gives_100(self):
+        assert _score(**PERFECT)["score"] == 100.0
+
+    def test_all_terrible_gives_0(self):
+        assert _score(**TERRIBLE)["score"] == 0.0
+
+    def test_all_midpoint_gives_50(self):
+        assert abs(_score(**MIDPOINT)["score"] - 50.0) < 0.01
+
+    def test_custom_weights_spread_only(self):
+        w = {"spread": 1, "depth": 0, "trade_rate": 0, "noise": 0}
+        r = _score(spread_bps=0.5, depth_usd=0.0, trade_rate=0.0, noise_ratio=1.0, weights=w)
+        assert r["score"] == 100.0
+
+    def test_custom_weights_noise_only(self):
+        w = {"spread": 0, "depth": 0, "trade_rate": 0, "noise": 1}
+        r = _score(spread_bps=50.0, depth_usd=0.0, trade_rate=0.0, noise_ratio=0.0, weights=w)
+        assert r["score"] == 100.0
+
+    def test_custom_weights_normalized_proportionally(self):
+        # Scaling all weights by same factor must not change the score
+        w1 = {"spread": 1, "depth": 1, "trade_rate": 1, "noise": 1}
+        w2 = {"spread": 3, "depth": 3, "trade_rate": 3, "noise": 3}
+        r1 = _score(**MIDPOINT, weights=w1)
+        r2 = _score(**MIDPOINT, weights=w2)
+        assert abs(r1["score"] - r2["score"]) < 1e-9
+
+    def test_score_increases_with_better_spread(self):
+        r_good = _score(spread_bps=1.0,  depth_usd=1e6, trade_rate=1.0, noise_ratio=0.5)
+        r_bad  = _score(spread_bps=20.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.5)
+        assert r_good["score"] > r_bad["score"]
+
+    def test_score_increases_with_more_depth(self):
+        r_deep    = _score(spread_bps=5.0, depth_usd=2_000_000.0, trade_rate=1.0, noise_ratio=0.5)
+        r_shallow = _score(spread_bps=5.0, depth_usd=50_000.0,    trade_rate=1.0, noise_ratio=0.5)
+        assert r_deep["score"] > r_shallow["score"]
+
+    def test_score_increases_with_higher_trade_rate(self):
+        r_active = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=5.0, noise_ratio=0.5)
+        r_slow   = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=0.1, noise_ratio=0.5)
+        assert r_active["score"] > r_slow["score"]
+
+    def test_score_decreases_with_more_noise(self):
+        r_clean = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.1)
+        r_noisy = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=1.0, noise_ratio=0.9)
+        assert r_clean["score"] > r_noisy["score"]
+
+
+# ── TestGradeLabel ────────────────────────────────────────────────────────────
+
+def _score_at(target: float):
+    """Return result with composite == target by isolating spread component."""
+    # spread_score = 100*(50-spread)/(50-0.5) = target
+    # → spread = 50 - target*(50-0.5)/100
+    spread = 50.0 - target * (50.0 - 0.5) / 100.0
+    w = {"spread": 1, "depth": 0, "trade_rate": 0, "noise": 0}
+    return _score(spread_bps=spread, depth_usd=0.0, trade_rate=0.0, noise_ratio=0.0, weights=w)
+
+
+class TestGradeLabel:
+    def test_grade_A_at_80(self):
+        r = _score_at(80.0)
+        assert r["grade"] == "A"
+        assert r["label"] == "excellent"
+
+    def test_grade_A_at_100(self):
+        assert _score(**PERFECT)["grade"] == "A"
+
+    def test_grade_B_at_60(self):
+        r = _score_at(60.0)
+        assert r["grade"] == "B"
+        assert r["label"] == "good"
+
+    def test_grade_B_just_below_A(self):
+        assert _score_at(79.0)["grade"] == "B"
+
+    def test_grade_C_at_40(self):
+        r = _score_at(40.0)
+        assert r["grade"] == "C"
+        assert r["label"] == "fair"
+
+    def test_grade_C_just_below_B(self):
+        assert _score_at(59.0)["grade"] == "C"
+
+    def test_grade_D_at_20(self):
+        r = _score_at(20.0)
+        assert r["grade"] == "D"
+        assert r["label"] == "poor"
+
+    def test_grade_D_just_below_C(self):
+        assert _score_at(39.0)["grade"] == "D"
+
+    def test_grade_F_at_0(self):
+        r = _score(**TERRIBLE)
+        assert r["grade"] == "F"
+        assert r["label"] == "very poor"
+
+    def test_grade_F_just_below_D(self):
+        assert _score_at(10.0)["grade"] == "F"
+        assert _score_at(10.0)["label"] == "very poor"
+
+
+# ── TestEdgeCases ─────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_negative_depth_same_as_zero(self):
+        r1 = _score(spread_bps=5.0, depth_usd=-1000.0, trade_rate=1.0, noise_ratio=0.5)
+        r2 = _score(spread_bps=5.0, depth_usd=0.0,     trade_rate=1.0, noise_ratio=0.5)
+        assert r1["score"] == r2["score"]
+
+    def test_negative_trade_rate_same_as_zero(self):
+        r1 = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=-1.0, noise_ratio=0.5)
+        r2 = _score(spread_bps=5.0, depth_usd=1e6, trade_rate=0.0,  noise_ratio=0.5)
+        assert r1["score"] == r2["score"]
+
+    def test_all_extreme_high_clamped_to_100(self):
+        r = _score(spread_bps=-100.0, depth_usd=1e9, trade_rate=1000.0, noise_ratio=-10.0)
+        assert r["score"] == 100.0
+
+    def test_component_values_reflect_inputs(self):
+        r = _score(spread_bps=7.5, depth_usd=300_000.0, trade_rate=2.5, noise_ratio=0.3)
+        c = r["components"]
+        assert c["spread"]["value"] == 7.5
+        assert c["depth"]["value"] == 300_000.0
+        assert c["trade_rate"]["value"] == 2.5
+        assert c["noise"]["value"] == 0.3
+
+    def test_default_weights_match_expected_values(self):
+        w = _score(**PERFECT)["weights"]
+        assert abs(w["spread"] - 0.35) < 1e-9
+        assert abs(w["depth"] - 0.30) < 1e-9
+        assert abs(w["trade_rate"] - 0.20) < 1e-9
+        assert abs(w["noise"] - 0.15) < 1e-9


### PR DESCRIPTION
Composite 0-100 quality score from spread, depth, trade rate, noise ratio. Includes API endpoint and frontend card.

## Changes

- `compute_market_microstructure_score()` in `backend/metrics.py`: pure function computing weighted composite of 4 components with letter grades A–F
  - **Spread** (35%): linear score, lower bid-ask spread in bps = better
  - **Depth** (30%): log-linear score, higher USD order book depth = better
  - **Trade Rate** (20%): log-linear score, higher trades/s = better
  - **Noise** (15%): inverted linear score, lower Kalman deviation % = better
- `GET /api/market-microstructure?symbol=...&window=300` in `backend/api.py`: gathers spread stats, order book depth, recent trades, and Kalman noise in parallel
- **Microstructure Quality card** in `frontend/index.html` + `app.js`: displays composite score with grade badge and per-component breakdown (score + raw value)
- 63 unit tests covering all components, composite weighting, custom weights, grade/label boundaries, and edge cases

## Test plan
- [ ] `pytest tests/test_microstructure_score.py` — all 63 tests pass
- [ ] Dashboard shows Microstructure Quality card after page load
- [ ] Grade badge updates color: green (A), blue (B), yellow (C), red (D/F)
- [ ] Component scores reflect actual market conditions (spread widening → spread score drops)
- [ ] `/api/market-microstructure?symbol=BTCUSDT` returns valid JSON with score, grade, components

🤖 Generated with [Claude Code](https://claude.com/claude-code)