### PR TITLE
feat: inter-exchange OI divergence detector

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -70,6 +70,7 @@ from metrics import (
     compute_price_ladder,
     compute_market_microstructure_score,
     compute_session_stats,
+    compute_inter_exchange_oi_divergence,
 )
 
 router = APIRouter(prefix="/api")
@@ -4508,5 +4509,66 @@ async def market_microstructure_endpoint(
             "trade_rate": round(trade_rate, 4),
             "noise_ratio": round(noise_ratio, 6),
         },
+        **result,
+    })
+
+
+@router.get("/oi-divergence")
+async def oi_divergence_endpoint(
+    symbol: str = Query(...),
+    window: int = Query(3600),
+    exchanges: str = Query("binance,bybit,okx"),
+    min_divergence_pct: float = Query(3.0),
+):
+    """Detect OI divergence across exchanges for the same symbol.
+
+    Fetches OI history for the requested exchanges, groups by exchange,
+    then computes % change and checks if any exchange deviates significantly
+    from the group mean. Fires an alert automatically on divergence.
+    """
+    exchange_list = [e.strip().lower() for e in exchanges.split(",") if e.strip()]
+    since = time.time() - window
+
+    # Fetch all OI rows for this symbol in one query, then group by exchange
+    all_oi = await get_oi_history(limit=5000, since=since, symbol=symbol)
+
+    oi_by_exchange: dict = {}
+    for row in all_oi:
+        ex = (row.get("exchange") or "").lower()
+        if ex in exchange_list:
+            oi_by_exchange.setdefault(ex, []).append({
+                "ts":       float(row["ts"]),
+                "oi_value": float(row["oi_value"]),
+            })
+
+    # Ensure ascending time order per exchange
+    for ex in oi_by_exchange:
+        oi_by_exchange[ex].sort(key=lambda r: r["ts"])
+
+    result = compute_inter_exchange_oi_divergence(
+        oi_by_exchange,
+        min_divergence_pct=min_divergence_pct,
+    )
+
+    # Fire alert on divergence
+    if result["divergence"]:
+        await insert_alert(
+            symbol=symbol,
+            alert_type="oi_divergence",
+            severity=result["severity"],
+            description=result["description"],
+            data={
+                "divergence_pct":     result["divergence_pct"],
+                "diverging_exchange": result["diverging_exchange"],
+                "mean_pct_change":    result["mean_pct_change"],
+                "opposing":           result["opposing"],
+            },
+        )
+
+    return JSONResponse({
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        "exchanges_queried": exchange_list,
         **result,
     })

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -3812,3 +3812,137 @@ def compute_session_stats(trades, session_start=None):
         "price_high":         round(price_high, 8),
         "price_low":          round(price_low if price_low != float("inf") else 0.0, 8),
     }
+
+
+def compute_inter_exchange_oi_divergence(
+    oi_by_exchange: dict,
+    min_divergence_pct: float = 3.0,
+) -> dict:
+    """Detect OI divergence across exchanges for the same symbol.
+
+    For each exchange, computes % change in OI from the first to last snapshot,
+    then flags if any exchange's change deviates significantly from the group mean.
+
+    Args:
+        oi_by_exchange: {"binance": [{"ts": float, "oi_value": float}, ...], ...}
+            Each list sorted ascending by ts; exchanges with <2 snapshots are skipped.
+        min_divergence_pct: alert threshold — max deviation from mean must be ≥ this
+            to trigger a divergence event (default: 3.0%).
+
+    Returns dict with keys:
+        divergence, divergence_pct, mean_pct_change, diverging_exchange,
+        opposing, severity, alert, exchange_count, exchanges, description,
+        min_divergence_pct
+    Severity bands: none → low → medium → high (opposing always → high).
+    """
+    _empty = {
+        "divergence":         False,
+        "divergence_pct":     0.0,
+        "mean_pct_change":    0.0,
+        "diverging_exchange": None,
+        "opposing":           False,
+        "severity":           "none",
+        "alert":              False,
+        "exchange_count":     0,
+        "exchanges":          {},
+        "description":        "Insufficient data across exchanges",
+        "min_divergence_pct": min_divergence_pct,
+    }
+
+    if not oi_by_exchange:
+        return _empty
+
+    # ── Per-exchange % change ─────────────────────────────────────────────────
+    ex_stats: dict = {}
+    for exchange, snapshots in oi_by_exchange.items():
+        if len(snapshots) < 2:
+            continue
+        oi_start = float(snapshots[0]["oi_value"])
+        oi_end   = float(snapshots[-1]["oi_value"])
+        pct_change = (oi_end - oi_start) / oi_start * 100 if oi_start != 0 else 0.0
+        ex_stats[exchange] = {
+            "pct_change":     round(pct_change, 4),
+            "latest_oi":      round(oi_end, 6),
+            "first_oi":       round(oi_start, 6),
+            "direction":      "up" if pct_change > 0 else ("down" if pct_change < 0 else "flat"),
+            "snapshot_count": len(snapshots),
+        }
+
+    if len(ex_stats) < 2:
+        result = dict(_empty)
+        result["exchange_count"] = len(ex_stats)
+        result["exchanges"] = {ex: {**s, "deviation": 0.0} for ex, s in ex_stats.items()}
+        result["description"] = (
+            f"Insufficient exchanges with data (need ≥2, got {len(ex_stats)})"
+        )
+        return result
+
+    # ── Mean and deviations ───────────────────────────────────────────────────
+    pcts      = {ex: s["pct_change"] for ex, s in ex_stats.items()}
+    mean_pct  = sum(pcts.values()) / len(pcts)
+    deviations = {ex: pct - mean_pct for ex, pct in pcts.items()}
+
+    divergence_pct     = max(abs(d) for d in deviations.values())
+    diverging_exchange = max(deviations, key=lambda ex: abs(deviations[ex]))
+
+    # ── Opposing flag ─────────────────────────────────────────────────────────
+    pct_values = list(pcts.values())
+    opposing = any(p > 0 for p in pct_values) and any(p < 0 for p in pct_values)
+
+    # ── Divergence flag ───────────────────────────────────────────────────────
+    divergence = divergence_pct >= min_divergence_pct
+
+    # ── Severity ─────────────────────────────────────────────────────────────
+    if not divergence:
+        severity = "none"
+    elif opposing:
+        severity = "high"
+    elif divergence_pct >= 2 * min_divergence_pct:
+        severity = "medium"
+    else:
+        severity = "low"
+
+    # ── Build per-exchange output ─────────────────────────────────────────────
+    exchanges_out = {
+        ex: {**s, "deviation": round(deviations[ex], 4)}
+        for ex, s in ex_stats.items()
+    }
+
+    # ── Description ──────────────────────────────────────────────────────────
+    if divergence:
+        div_dev = deviations[diverging_exchange]
+        dev_str = f"{div_dev:+.2f}%"
+        if opposing:
+            up_exs   = [ex for ex, p in pcts.items() if p > 0]
+            down_exs = [ex for ex, p in pcts.items() if p < 0]
+            description = (
+                f"\u26a0 OI direction conflict: "
+                f"{', '.join(up_exs)} up vs {', '.join(down_exs)} down — "
+                f"{diverging_exchange} deviates {dev_str} from mean {mean_pct:+.2f}% "
+                f"(severity: {severity})"
+            )
+        else:
+            description = (
+                f"OI divergence on {diverging_exchange}: "
+                f"{dev_str} from mean {mean_pct:+.2f}% "
+                f"(severity: {severity})"
+            )
+    else:
+        description = (
+            f"No OI divergence (max dev: {divergence_pct:.2f}%, "
+            f"threshold: {min_divergence_pct:.1f}%)"
+        )
+
+    return {
+        "divergence":         divergence,
+        "divergence_pct":     round(divergence_pct, 4),
+        "mean_pct_change":    round(mean_pct, 4),
+        "diverging_exchange": diverging_exchange if divergence else None,
+        "opposing":           opposing,
+        "severity":           severity,
+        "alert":              divergence,
+        "exchange_count":     len(ex_stats),
+        "exchanges":          exchanges_out,
+        "description":        description,
+        "min_divergence_pct": min_divergence_pct,
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -665,6 +665,73 @@ async function renderPhase() {
   }
 }
 
+// ── Render: Inter-Exchange OI Divergence ─────────────────────────────────────
+async function renderOiDivergence() {
+  const sym = encodeURIComponent(activeSymbol);
+  const data = await apiFetch(`/oi-divergence?symbol=${sym}&window=3600`);
+  if (!data) return;
+
+  const badge = document.getElementById('oi-divergence-badge');
+  if (badge) {
+    if (data.divergence) {
+      const sevClass = data.severity === 'high'   ? 'badge-red'
+                     : data.severity === 'medium' ? 'badge-yellow'
+                     : 'badge-blue';
+      badge.textContent = data.severity.toUpperCase()
+        + (data.opposing ? ' · OPPOSING' : '');
+      badge.className = `card-badge ${sevClass}`;
+      badge.style.display = 'inline-block';
+    } else {
+      badge.style.display = 'none';
+    }
+  }
+
+  const el = document.getElementById('oi-divergence-content');
+  if (!el) return;
+
+  const exs = data.exchanges || {};
+  const exNames = Object.keys(exs);
+
+  if (!exNames.length) {
+    el.innerHTML = '<div class="text-muted" style="font-size:11px;">No exchange data yet</div>';
+    return;
+  }
+
+  const divColor = data.divergence
+    ? (data.severity === 'high' ? 'var(--red)' : data.severity === 'medium' ? 'var(--yellow)' : '#64b4ff')
+    : 'var(--green)';
+
+  const rows = exNames.map(ex => {
+    const e = exs[ex];
+    const pctStr = e.pct_change >= 0 ? `+${e.pct_change.toFixed(2)}%` : `${e.pct_change.toFixed(2)}%`;
+    const devStr = e.deviation  >= 0 ? `+${e.deviation.toFixed(2)}%`  : `${e.deviation.toFixed(2)}%`;
+    const dirColor = e.direction === 'up' ? 'var(--green)' : e.direction === 'down' ? 'var(--red)' : 'var(--muted)';
+    const isDiverging = data.diverging_exchange === ex;
+    return `
+      <div class="metric-box" style="${isDiverging ? 'border:1px solid ' + divColor + ';border-radius:6px;' : ''}">
+        <div class="metric-label">${ex.charAt(0).toUpperCase() + ex.slice(1)}</div>
+        <div class="metric-value" style="color:${dirColor}">${pctStr}</div>
+        <div class="metric-label">dev ${devStr}</div>
+      </div>`;
+  }).join('');
+
+  const meanStr = data.mean_pct_change >= 0
+    ? `+${data.mean_pct_change.toFixed(2)}%`
+    : `${data.mean_pct_change.toFixed(2)}%`;
+
+  el.innerHTML = `
+    <div class="phase-metrics">
+      ${rows}
+      <div class="metric-box">
+        <div class="metric-label">Mean</div>
+        <div class="metric-value" style="color:var(--muted)">${meanStr}</div>
+        <div class="metric-label">max dev ${data.divergence_pct.toFixed(2)}%</div>
+      </div>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-top:6px;line-height:1.4">${data.description || ''}</div>
+  `;
+}
+
 // ── Render: Microstructure Score ──────────────────────────────────────────────
 function _compColor(score) {
   if (score == null) return 'var(--muted)';
@@ -822,6 +889,7 @@ async function refresh() {
     renderTradeTape(),
     renderVolumeImbalance(),
     renderPhase(),
+    renderOiDivergence(),
     renderMicrostructure(),
   ]);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,6 +131,18 @@
     </div>
   </section>
 
+  <!-- Inter-Exchange OI Divergence -->
+  <section class="card" id="card-oi-divergence">
+    <div class="card-header">
+      <span class="card-title">OI Divergence</span>
+      <span id="oi-divergence-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">Binance · Bybit · OKX · 1h</span>
+    </div>
+    <div id="oi-divergence-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- Market Microstructure Score -->
   <section class="card" id="card-microstructure">
     <div class="card-header">

--- a/tests/test_inter_exchange_oi_divergence.py
+++ b/tests/test_inter_exchange_oi_divergence.py
@@ -1,0 +1,375 @@
+"""Tests for compute_inter_exchange_oi_divergence."""
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+from metrics import compute_inter_exchange_oi_divergence
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _snap(ts, oi):
+    return {"ts": float(ts), "oi_value": float(oi)}
+
+
+def _run(oi_by_exchange, **kwargs):
+    return compute_inter_exchange_oi_divergence(oi_by_exchange, **kwargs)
+
+
+# Pre-built scenarios (verified by hand)
+
+# All three exchanges up exactly 5% → zero deviation
+SAME_UP_5 = {
+    "binance": [_snap(0, 100), _snap(60, 105)],   # +5.0%
+    "bybit":   [_snap(0, 200), _snap(60, 210)],   # +5.0%
+    "okx":     [_snap(0, 300), _snap(60, 315)],   # +5.0%
+}
+
+# Binance/Bybit +8%, OKX -3%
+# mean = (8+8-3)/3 = 4.333…%, okx dev = -3-4.333 = -7.333% → divergence + opposing
+OPPOSING = {
+    "binance": [_snap(0, 100), _snap(60, 108)],   # +8%
+    "bybit":   [_snap(0, 200), _snap(60, 216)],   # +8%
+    "okx":     [_snap(0, 300), _snap(60, 291)],   # -3%
+}
+
+# Binance +10%, Bybit +2% — same direction, divergence_pct=4% (> 3% threshold, < 6%)
+SAME_DIR_LOW = {
+    "binance": [_snap(0, 100), _snap(60, 110)],   # +10%
+    "bybit":   [_snap(0, 200), _snap(60, 204)],   # +2%
+}
+
+# Binance +14%, Bybit +1% — same direction, divergence_pct=6.5% (>= 2×threshold=6)
+SAME_DIR_MEDIUM = {
+    "binance": [_snap(0, 100), _snap(60, 114)],   # +14%
+    "bybit":   [_snap(0, 200), _snap(60, 202)],   # +1%
+}
+
+
+# ── TestStructure ─────────────────────────────────────────────────────────────
+
+class TestStructure:
+    def test_returns_dict(self):
+        assert isinstance(_run(SAME_UP_5), dict)
+
+    def test_has_divergence_key(self):
+        assert "divergence" in _run(SAME_UP_5)
+
+    def test_has_divergence_pct_key(self):
+        assert "divergence_pct" in _run(SAME_UP_5)
+
+    def test_has_mean_pct_change_key(self):
+        assert "mean_pct_change" in _run(SAME_UP_5)
+
+    def test_has_diverging_exchange_key(self):
+        assert "diverging_exchange" in _run(SAME_UP_5)
+
+    def test_has_opposing_key(self):
+        assert "opposing" in _run(SAME_UP_5)
+
+    def test_has_severity_key(self):
+        assert "severity" in _run(SAME_UP_5)
+
+    def test_has_alert_key(self):
+        assert "alert" in _run(SAME_UP_5)
+
+    def test_has_exchange_count_key(self):
+        assert "exchange_count" in _run(SAME_UP_5)
+
+    def test_has_exchanges_key(self):
+        assert "exchanges" in _run(SAME_UP_5)
+
+    def test_has_description_key(self):
+        assert "description" in _run(SAME_UP_5)
+
+    def test_has_min_divergence_pct_key(self):
+        assert "min_divergence_pct" in _run(SAME_UP_5)
+
+    def test_exchange_count_matches_valid_input(self):
+        assert _run(SAME_UP_5)["exchange_count"] == 3
+
+    def test_per_exchange_has_pct_change(self):
+        r = _run(SAME_UP_5)
+        for ex in ("binance", "bybit", "okx"):
+            assert "pct_change" in r["exchanges"][ex]
+
+    def test_per_exchange_has_latest_oi(self):
+        r = _run(SAME_UP_5)
+        for ex in ("binance", "bybit", "okx"):
+            assert "latest_oi" in r["exchanges"][ex]
+
+    def test_per_exchange_has_deviation(self):
+        r = _run(SAME_UP_5)
+        for ex in ("binance", "bybit", "okx"):
+            assert "deviation" in r["exchanges"][ex]
+
+    def test_per_exchange_has_direction(self):
+        r = _run(SAME_UP_5)
+        for ex in ("binance", "bybit", "okx"):
+            assert "direction" in r["exchanges"][ex]
+
+    def test_alert_equals_divergence(self):
+        r1 = _run(SAME_UP_5)
+        r2 = _run(OPPOSING)
+        assert r1["alert"] == r1["divergence"]
+        assert r2["alert"] == r2["divergence"]
+
+    def test_description_is_string(self):
+        assert isinstance(_run(SAME_UP_5)["description"], str)
+        assert isinstance(_run(OPPOSING)["description"], str)
+
+
+# ── TestNoDivergence ──────────────────────────────────────────────────────────
+
+class TestNoDivergence:
+    def test_all_same_pct_no_divergence(self):
+        assert _run(SAME_UP_5)["divergence"] is False
+
+    def test_all_same_pct_divergence_pct_zero(self):
+        assert _run(SAME_UP_5)["divergence_pct"] == 0.0
+
+    def test_all_same_pct_severity_none(self):
+        assert _run(SAME_UP_5)["severity"] == "none"
+
+    def test_all_same_pct_diverging_exchange_none(self):
+        assert _run(SAME_UP_5)["diverging_exchange"] is None
+
+    def test_small_deviations_below_threshold(self):
+        # binance +2%, bybit +1% → mean=1.5%, max_dev=0.5% < 3%
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 102)],
+            "bybit":   [_snap(0, 100), _snap(60, 101)],
+        }
+        assert _run(data)["divergence"] is False
+
+    def test_below_threshold_no_alert(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 102)],
+            "bybit":   [_snap(0, 100), _snap(60, 101)],
+        }
+        assert _run(data)["alert"] is False
+
+
+# ── TestPctChange ─────────────────────────────────────────────────────────────
+
+class TestPctChange:
+    def test_up_10_pct(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 110)],
+            "bybit":   [_snap(0, 100), _snap(60, 110)],
+        }
+        r = _run(data)
+        assert abs(r["exchanges"]["binance"]["pct_change"] - 10.0) < 1e-6
+
+    def test_down_5_pct(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 95)],
+            "bybit":   [_snap(0, 100), _snap(60, 95)],
+        }
+        assert abs(_run(data)["exchanges"]["binance"]["pct_change"] - (-5.0)) < 1e-6
+
+    def test_flat_zero_pct(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 100)],
+            "bybit":   [_snap(0, 100), _snap(60, 100)],
+        }
+        assert _run(data)["exchanges"]["binance"]["pct_change"] == 0.0
+
+    def test_uses_first_and_last_snapshot_ignores_middle(self):
+        # Middle snapshot (200) is irrelevant — only first (100) and last (110) matter
+        data = {
+            "binance": [_snap(0, 100), _snap(30, 200), _snap(60, 110)],
+            "bybit":   [_snap(0, 100), _snap(60, 110)],
+        }
+        assert abs(_run(data)["exchanges"]["binance"]["pct_change"] - 10.0) < 1e-6
+
+    def test_latest_oi_is_last_snapshot_value(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 107.5)],
+            "bybit":   [_snap(0, 100), _snap(60, 107.5)],
+        }
+        assert abs(_run(data)["exchanges"]["binance"]["latest_oi"] - 107.5) < 1e-6
+
+    def test_exchange_with_single_snapshot_excluded(self):
+        data = {
+            "binance": [_snap(0, 100)],               # only 1 → excluded
+            "bybit":   [_snap(0, 200), _snap(60, 210)],
+            "okx":     [_snap(0, 300), _snap(60, 315)],
+        }
+        r = _run(data)
+        assert r["exchange_count"] == 2
+        assert "binance" not in r["exchanges"]
+
+    def test_zero_starting_oi_gives_zero_pct_change(self):
+        data = {
+            "binance": [_snap(0, 0), _snap(60, 100)],   # start=0 → pct=0
+            "bybit":   [_snap(0, 200), _snap(60, 210)],
+        }
+        assert _run(data)["exchanges"]["binance"]["pct_change"] == 0.0
+
+
+# ── TestDivergence ────────────────────────────────────────────────────────────
+
+class TestDivergence:
+    def test_divergence_detected(self):
+        assert _run(OPPOSING)["divergence"] is True
+
+    def test_diverging_exchange_identified(self):
+        # OKX has the biggest absolute deviation in OPPOSING scenario
+        assert _run(OPPOSING)["diverging_exchange"] == "okx"
+
+    def test_divergence_pct_correct(self):
+        # OPPOSING: mean=(8+8-3)/3=4.333%, okx_dev=|-3-4.333|=7.333%
+        r = _run(OPPOSING)
+        expected = abs(-3.0 - (8.0 + 8.0 - 3.0) / 3)
+        assert abs(r["divergence_pct"] - expected) < 0.001
+
+    def test_mean_pct_change_correct(self):
+        r = _run(OPPOSING)
+        expected = (8.0 + 8.0 - 3.0) / 3
+        assert abs(r["mean_pct_change"] - expected) < 0.001
+
+    def test_custom_threshold_triggers_at_higher_value(self):
+        # SAME_DIR_LOW has divergence_pct=4% > default 3% → True with 3%, False with 5%
+        assert _run(SAME_DIR_LOW)["divergence"] is True
+        assert _run(SAME_DIR_LOW, min_divergence_pct=5.0)["divergence"] is False
+
+    def test_exactly_at_threshold_triggers(self):
+        # binance +7%, bybit +1%: mean=4%, deviations=3.0% exactly = threshold
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 107)],
+            "bybit":   [_snap(0, 100), _snap(60, 101)],
+        }
+        assert _run(data)["divergence"] is True
+
+    def test_deviations_sum_near_zero(self):
+        # Deviations sum to ≈0 (mean property); tolerance accounts for 4dp rounding
+        r = _run(OPPOSING)
+        total = sum(v["deviation"] for v in r["exchanges"].values())
+        assert abs(total) < 1e-3
+
+    def test_min_divergence_pct_stored_in_result(self):
+        assert _run(SAME_UP_5, min_divergence_pct=5.0)["min_divergence_pct"] == 5.0
+
+
+# ── TestOpposing ──────────────────────────────────────────────────────────────
+
+class TestOpposing:
+    def test_opposing_true_when_up_and_down_present(self):
+        assert _run(OPPOSING)["opposing"] is True
+
+    def test_opposing_false_when_all_same_sign(self):
+        assert _run(SAME_DIR_LOW)["opposing"] is False
+
+    def test_opposing_false_when_all_flat(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 100)],
+            "bybit":   [_snap(0, 100), _snap(60, 100)],
+        }
+        assert _run(data)["opposing"] is False
+
+    def test_opposing_true_two_exchanges_opposite_directions(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 110)],  # +10%
+            "bybit":   [_snap(0, 100), _snap(60,  90)],  # -10%
+        }
+        assert _run(data)["opposing"] is True
+
+    def test_opposing_false_all_positive_including_small(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 110)],   # +10%
+            "bybit":   [_snap(0, 100), _snap(60, 100.1)], # +0.1%
+        }
+        assert _run(data)["opposing"] is False
+
+
+# ── TestSeverity ──────────────────────────────────────────────────────────────
+
+class TestSeverity:
+    def test_no_divergence_severity_none(self):
+        assert _run(SAME_UP_5)["severity"] == "none"
+
+    def test_opposing_divergence_severity_high(self):
+        assert _run(OPPOSING)["severity"] == "high"
+
+    def test_same_dir_low_severity_low(self):
+        # divergence_pct=4%, threshold=3%, not opposing, 4% < 2*3%=6%
+        assert _run(SAME_DIR_LOW)["severity"] == "low"
+
+    def test_same_dir_medium_severity_medium(self):
+        # divergence_pct=6.5%, threshold=3%, not opposing, 6.5% >= 2*3%=6%
+        assert _run(SAME_DIR_MEDIUM)["severity"] == "medium"
+
+    def test_opposing_and_small_divergence_still_high(self):
+        # opposing=True always means severity="high" when divergence=True
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 104)],   # +4%
+            "bybit":   [_snap(0, 100), _snap(60,  98)],   # -2%
+        }
+        # mean=1%, deviations=3% each, divergence_pct=3% >= threshold=3%
+        # opposing=True → severity="high"
+        r = _run(data)
+        assert r["divergence"] is True
+        assert r["opposing"] is True
+        assert r["severity"] == "high"
+
+    def test_below_threshold_always_none(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 102)],
+            "bybit":   [_snap(0, 100), _snap(60, 101)],
+        }
+        assert _run(data)["severity"] == "none"
+
+
+# ── TestEdgeCases ─────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_empty_input(self):
+        r = _run({})
+        assert r["divergence"] is False
+        assert r["exchange_count"] == 0
+
+    def test_single_exchange_only(self):
+        data = {"binance": [_snap(0, 100), _snap(60, 110)]}
+        r = _run(data)
+        assert r["divergence"] is False
+
+    def test_all_single_snapshots_insufficient(self):
+        data = {
+            "binance": [_snap(0, 100)],
+            "bybit":   [_snap(0, 200)],
+        }
+        r = _run(data)
+        assert r["divergence"] is False
+        assert r["exchange_count"] == 0
+
+    def test_direction_up(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 110)],
+            "bybit":   [_snap(0, 100), _snap(60, 110)],
+        }
+        assert _run(data)["exchanges"]["binance"]["direction"] == "up"
+
+    def test_direction_down(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 90)],
+            "bybit":   [_snap(0, 100), _snap(60, 90)],
+        }
+        assert _run(data)["exchanges"]["binance"]["direction"] == "down"
+
+    def test_direction_flat(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 100)],
+            "bybit":   [_snap(0, 100), _snap(60, 100)],
+        }
+        assert _run(data)["exchanges"]["binance"]["direction"] == "flat"
+
+    def test_two_exchanges_only_sufficient(self):
+        data = {
+            "binance": [_snap(0, 100), _snap(60, 110)],
+            "bybit":   [_snap(0, 100), _snap(60, 110)],
+        }
+        r = _run(data)
+        assert r["exchange_count"] == 2
+        assert isinstance(r["divergence"], bool)


### PR DESCRIPTION
Compares OI across Binance/Bybit/OKX for same symbol, detects divergence and fires alerts

## Changes

- **`compute_inter_exchange_oi_divergence()`** in `backend/metrics.py`: pure function
  - Per-exchange % OI change (first → last snapshot in window)
  - Group mean + per-exchange deviation from mean
  - Divergence flag when `max_deviation >= min_divergence_pct` (default 3%)
  - **Opposing** flag: True when ≥1 exchange is up while ≥1 is down (most dangerous signal)
  - Severity: `none → low → medium → high`; opposing always → `high`
  - Identifies `diverging_exchange` by name
- **`GET /api/oi-divergence`** in `backend/api.py`: fetches full OI history for the symbol, groups by exchange, calls `insert_alert()` automatically on any divergence
- **OI Divergence card** in `frontend/`: per-exchange % change tiles with deviation shown, diverging exchange highlighted, severity badge, human-readable description
- **58 unit tests** covering structure, no-divergence baseline, pct change math, divergence detection, opposing flag, severity bands, and edge cases

## Test plan
- [ ] `pytest tests/test_inter_exchange_oi_divergence.py` — all 58 tests pass
- [ ] `/api/oi-divergence?symbol=BTCUSDT` returns valid JSON with `divergence`, `exchanges`, `severity`
- [ ] Card shows per-exchange OI % change with deviation column
- [ ] When `opposing=true`, badge shows `HIGH · OPPOSING` in red
- [ ] Alert is inserted into alert history when divergence fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)