### PR TITLE
feat: whale order clustering map

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -71,6 +71,7 @@ from metrics import (
     compute_market_microstructure_score,
     compute_session_stats,
     compute_inter_exchange_oi_divergence,
+    compute_whale_clustering,
 )
 
 router = APIRouter(prefix="/api")
@@ -4565,10 +4566,41 @@ async def oi_divergence_endpoint(
             },
         )
 
+@router.get("/whale-clustering")
+async def whale_clustering_endpoint(
+    symbol: str = Query(...),
+    window: int = Query(1800, description="Lookback seconds (default 30 min)"),
+    bin_size: float = Query(None, description="Fixed price bin width in USD"),
+    n_bins: int = Query(50, description="Number of bins when bin_size not set"),
+    zone_sigma: float = Query(1.0, description="Sigma multiplier for zone threshold"),
+    min_whale_usd: float = Query(10_000, description="Minimum trade size to include"),
+):
+    """Group whale trades by price level and detect high-volume concentration zones."""
+    since = time.time() - window
+    raw_trades = await get_whale_trades(symbol=symbol, since=since, min_value_usd=min_whale_usd)
+
+    trades = [
+        {
+            "price":     float(t["price"]),
+            "qty":       float(t["qty"]),
+            "side":      str(t.get("side", "buy")).lower(),
+            "value_usd": float(t["value_usd"]),
+        }
+        for t in raw_trades
+    ]
+
+    result = compute_whale_clustering(
+        trades,
+        bin_size=bin_size,
+        n_bins=n_bins,
+        zone_sigma=zone_sigma,
+    )
+
     return JSONResponse({
         "status": "ok",
         "symbol": symbol,
         "window_seconds": window,
         "exchanges_queried": exchange_list,
+        "min_whale_usd": min_whale_usd,
         **result,
     })

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -3946,3 +3946,141 @@ def compute_inter_exchange_oi_divergence(
         "description":        description,
         "min_divergence_pct": min_divergence_pct,
     }
+
+
+def compute_whale_clustering(
+    trades: list,
+    *,
+    bin_size: float = None,
+    n_bins: int = 50,
+    zone_sigma: float = 1.0,
+) -> dict:
+    """Group trades into price bins and detect high-volume concentration zones.
+
+    Args:
+        trades: list of dicts with keys price, qty, side, value_usd
+        bin_size: fixed price bin width; if None, computed from range / n_bins
+        n_bins: number of bins to use when bin_size is not provided
+        zone_sigma: threshold = mean + zone_sigma * std over ALL bins (incl. empty)
+    """
+    import math as _math
+
+    EMPTY = {
+        "trade_count": 0,
+        "bins": [],
+        "zones": [],
+        "top_zone_price": None,
+        "bin_size": bin_size or 0.0,
+        "non_empty_bins": 0,
+        "total_usd": 0.0,
+        "price_min": None,
+        "price_max": None,
+        "zone_threshold_usd": 0.0,
+    }
+
+    if not trades:
+        return EMPTY
+
+    prices = [float(t["price"]) for t in trades]
+    price_min = min(prices)
+    price_max = max(prices)
+
+    # Determine bin_size
+    if bin_size is None:
+        rng = price_max - price_min
+        if rng == 0:
+            bin_size = 1.0
+        else:
+            bin_size = rng / n_bins
+    bin_size = float(bin_size)
+
+    # Accumulate into bins (keyed by bin index)
+    bins_data: dict = {}
+    for t in trades:
+        price = float(t["price"])
+        value = float(t["value_usd"])
+        side = str(t.get("side", "buy")).lower()
+        idx = int((price - price_min) / bin_size)
+        if idx not in bins_data:
+            bins_data[idx] = {"buy_usd": 0.0, "sell_usd": 0.0, "count": 0,
+                               "buy_count": 0, "sell_count": 0}
+        b = bins_data[idx]
+        b["count"] += 1
+        if side == "buy":
+            b["buy_usd"] += value
+            b["buy_count"] += 1
+        else:
+            b["sell_usd"] += value
+            b["sell_count"] += 1
+
+    # Zone detection over ALL bins including zeros (consistent with price_ladder)
+    if bins_data:
+        max_idx = max(bins_data.keys())
+        all_vols = [
+            bins_data[i]["buy_usd"] + bins_data[i]["sell_usd"] if i in bins_data else 0.0
+            for i in range(max_idx + 1)
+        ]
+    else:
+        all_vols = []
+
+    n_all = len(all_vols)
+    mean_vol = sum(all_vols) / n_all if n_all else 0.0
+    variance = sum((v - mean_vol) ** 2 for v in all_vols) / n_all if n_all else 0.0
+    std_vol = _math.sqrt(variance)
+    zone_threshold = mean_vol + zone_sigma * std_vol
+
+    # Build output bin list (non-empty only, sorted ascending)
+    result_bins = []
+    for idx in sorted(bins_data.keys()):
+        b = bins_data[idx]
+        price_low = price_min + idx * bin_size
+        price_high = price_low + bin_size
+        price_mid = price_low + bin_size / 2.0
+        buy_usd = b["buy_usd"]
+        sell_usd = b["sell_usd"]
+        total_usd = buy_usd + sell_usd
+
+        is_zone = total_usd > zone_threshold
+
+        if buy_usd > sell_usd:
+            dominance = "buy"
+        elif sell_usd > buy_usd:
+            dominance = "sell"
+        else:
+            dominance = "neutral"
+
+        result_bins.append({
+            "price_low":    price_low,
+            "price_high":   price_high,
+            "price_mid":    price_mid,
+            "total_usd":    total_usd,
+            "buy_usd":      buy_usd,
+            "sell_usd":     sell_usd,
+            "count":        b["count"],
+            "buy_count":    b["buy_count"],
+            "sell_count":   b["sell_count"],
+            "is_zone":      is_zone,
+            "dominance":    dominance,
+        })
+
+    zone_bins = [b for b in result_bins if b["is_zone"]]
+    zones = [b["price_mid"] for b in zone_bins]
+    top_zone_price = (
+        max(zone_bins, key=lambda b: b["total_usd"])["price_mid"]
+        if zone_bins else None
+    )
+
+    total_usd = sum(b["total_usd"] for b in result_bins)
+
+    return {
+        "trade_count":        len(trades),
+        "bins":               result_bins,
+        "zones":              zones,
+        "top_zone_price":     top_zone_price,
+        "bin_size":           bin_size,
+        "non_empty_bins":     len(result_bins),
+        "total_usd":          total_usd,
+        "price_min":          price_min,
+        "price_max":          price_max,
+        "zone_threshold_usd": zone_threshold,
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -876,6 +876,73 @@ function appendAlertFeed(msg) {
   }
 }
 
+// ── Whale Order Clustering ────────────────────────────────────────────────────
+async function renderWhaleClustering() {
+  const el = document.getElementById('whale-clustering-content');
+  const badge = document.getElementById('whale-clustering-badge');
+  if (!el) return;
+
+  const sym = activeSymbol;
+  let data;
+  try {
+    const res = await fetch(`/api/whale-clustering?symbol=${sym}&window=1800`);
+    data = await res.json();
+  } catch {
+    el.innerHTML = '<div class="text-muted" style="font-size:11px;">Unavailable</div>';
+    return;
+  }
+
+  if (!data || data.trade_count === 0) {
+    el.innerHTML = '<div class="text-muted" style="font-size:11px;">No whale trades in window</div>';
+    badge.style.display = 'none';
+    return;
+  }
+
+  const zones = data.zones || [];
+  const bins = data.bins || [];
+
+  if (zones.length > 0) {
+    badge.textContent = `${zones.length} zone${zones.length > 1 ? 's' : ''}`;
+    badge.style.display = 'inline-block';
+    badge.style.background = 'var(--accent, #f59e0b)';
+  } else {
+    badge.style.display = 'none';
+  }
+
+  const fmtK = v => v >= 1e6 ? `$${(v/1e6).toFixed(2)}M` : v >= 1e3 ? `$${(v/1e3).toFixed(1)}K` : `$${v.toFixed(0)}`;
+  const topZone = data.top_zone_price != null ? `$${Number(data.top_zone_price).toLocaleString()}` : '—';
+
+  let html = `<div style="display:flex;gap:16px;flex-wrap:wrap;font-size:11px;margin-bottom:8px;padding:0 2px;">
+    <span>Trades <b>${data.trade_count}</b></span>
+    <span>Volume <b>${fmtK(data.total_usd)}</b></span>
+    <span>Bins <b>${data.non_empty_bins}</b></span>
+    <span>Zones <b>${zones.length}</b></span>
+    <span>Top Zone <b>${topZone}</b></span>
+  </div>`;
+
+  if (bins.length > 0) {
+    const maxVol = Math.max(...bins.map(b => b.total_usd));
+    html += '<div style="display:flex;flex-direction:column;gap:2px;font-size:10px;">';
+    for (const b of [...bins].reverse()) {
+      const pct = maxVol > 0 ? (b.total_usd / maxVol * 100).toFixed(1) : 0;
+      const barColor = b.is_zone
+        ? 'var(--accent, #f59e0b)'
+        : b.dominance === 'buy' ? 'var(--bull, #22c55e)' : b.dominance === 'sell' ? 'var(--bear, #ef4444)' : 'var(--muted, #6b7280)';
+      html += `<div style="display:flex;align-items:center;gap:6px;">
+        <span style="width:56px;text-align:right;color:var(--muted);">$${Number(b.price_mid).toLocaleString()}</span>
+        <div style="flex:1;background:var(--bg2,#1e1e2e);border-radius:2px;height:10px;position:relative;">
+          <div style="width:${pct}%;height:100%;background:${barColor};border-radius:2px;opacity:${b.is_zone ? 1 : 0.55};"></div>
+        </div>
+        <span style="width:44px;color:var(--muted);">${fmtK(b.total_usd)}</span>
+        ${b.is_zone ? '<span style="color:var(--accent,#f59e0b);font-weight:700;">ZONE</span>' : ''}
+      </div>`;
+    }
+    html += '</div>';
+  }
+
+  el.innerHTML = html;
+}
+
 // ── Main Refresh Loop ─────────────────────────────────────────────────────────
 async function refresh() {
   if (!activeSymbol) return;
@@ -891,6 +958,7 @@ async function refresh() {
     renderPhase(),
     renderOiDivergence(),
     renderMicrostructure(),
+    renderWhaleClustering(),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,6 +139,14 @@
       <span class="card-meta">Binance · Bybit · OKX · 1h</span>
     </div>
     <div id="oi-divergence-content">
+  <!-- Whale Order Clustering -->
+  <section class="card" id="card-whale-clustering">
+    <div class="card-header">
+      <span class="card-title">Whale Clustering</span>
+      <span id="whale-clustering-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">price zones · 30 min</span>
+    </div>
+    <div id="whale-clustering-content">
       <div class="text-muted" style="font-size:11px;">Loading…</div>
     </div>
   </section>

--- a/tests/test_whale_clustering.py
+++ b/tests/test_whale_clustering.py
@@ -1,0 +1,339 @@
+"""Tests for compute_whale_clustering."""
+import math
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+from metrics import compute_whale_clustering
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _trade(price, value_usd, side="buy", qty=None):
+    if qty is None:
+        qty = value_usd / price
+    return {"price": float(price), "qty": float(qty), "side": side, "value_usd": float(value_usd)}
+
+
+def _run(trades, **kwargs):
+    return compute_whale_clustering(trades, **kwargs)
+
+
+# Pre-built scenario with known math (bin_size=10, zone_sigma=0 → threshold=mean)
+#
+#   price 100: buy 10k + sell 5k  → total 15k, bin 0
+#   price 110: buy 30k + sell 10k → total 40k, bin 1   ← DOMINANT
+#   price 120: buy  8k             → total  8k, bin 2
+#
+# all_vols = [15k, 40k, 8k], mean = 21k, zone_threshold (sigma=0) = 21k
+# 40k > 21k → bin1 is zone; 15k, 8k are not
+
+TRADES_3BIN = [
+    _trade(100, 10_000, "buy"),
+    _trade(100,  5_000, "sell"),
+    _trade(110, 30_000, "buy"),
+    _trade(110, 10_000, "sell"),
+    _trade(120,  8_000, "buy"),
+]
+
+
+# ── TestStructure ─────────────────────────────────────────────────────────────
+
+class TestStructure:
+    def test_returns_dict(self):
+        assert isinstance(_run(TRADES_3BIN, bin_size=10), dict)
+
+    def test_has_bins_key(self):
+        assert "bins" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_zones_key(self):
+        assert "zones" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_top_zone_price_key(self):
+        assert "top_zone_price" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_bin_size_key(self):
+        assert "bin_size" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_trade_count_key(self):
+        assert "trade_count" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_total_usd_key(self):
+        assert "total_usd" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_price_min_key(self):
+        assert "price_min" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_price_max_key(self):
+        assert "price_max" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_zone_threshold_usd_key(self):
+        assert "zone_threshold_usd" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_has_non_empty_bins_key(self):
+        assert "non_empty_bins" in _run(TRADES_3BIN, bin_size=10)
+
+    def test_bins_is_list(self):
+        assert isinstance(_run(TRADES_3BIN, bin_size=10)["bins"], list)
+
+    def test_zones_is_list(self):
+        assert isinstance(_run(TRADES_3BIN, bin_size=10)["zones"], list)
+
+    def test_bin_has_required_fields(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        required = {"price_low", "price_high", "price_mid", "total_usd",
+                    "buy_usd", "sell_usd", "count", "buy_count", "sell_count",
+                    "is_zone", "dominance"}
+        for b in r["bins"]:
+            assert required.issubset(b.keys()), f"bin missing keys: {required - b.keys()}"
+
+    def test_bin_size_reflected_in_result(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        assert r["bin_size"] == 10.0
+
+
+# ── TestBinning ───────────────────────────────────────────────────────────────
+
+class TestBinning:
+    def test_same_price_same_bin(self):
+        trades = [_trade(100, 10_000), _trade(100, 20_000)]
+        r = _run(trades, bin_size=10)
+        assert len(r["bins"]) == 1
+        assert r["bins"][0]["count"] == 2
+
+    def test_different_prices_different_bins(self):
+        trades = [_trade(100, 10_000), _trade(150, 20_000)]
+        r = _run(trades, bin_size=10)
+        assert len(r["bins"]) == 2
+
+    def test_trades_within_same_bin_aggregated(self):
+        # 100 and 109 both fall in [100, 110) with bin_size=10
+        trades = [_trade(100, 10_000), _trade(109, 5_000)]
+        r = _run(trades, bin_size=10)
+        assert len(r["bins"]) == 1
+        assert abs(r["bins"][0]["total_usd"] - 15_000) < 1
+
+    def test_trade_at_bin_boundary_goes_to_next(self):
+        # price=110 is at the boundary: idx = (110-100)/10 = 1 (next bin)
+        trades = [_trade(100, 10_000), _trade(110, 20_000)]
+        r = _run(trades, bin_size=10)
+        assert len(r["bins"]) == 2
+
+    def test_bins_sorted_ascending_by_price(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        lows = [b["price_low"] for b in r["bins"]]
+        assert lows == sorted(lows)
+
+    def test_price_mid_is_bin_center(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        for b in r["bins"]:
+            expected_mid = b["price_low"] + 10 / 2
+            assert abs(b["price_mid"] - expected_mid) < 1e-9
+
+    def test_price_high_equals_low_plus_bin_size(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        for b in r["bins"]:
+            assert abs(b["price_high"] - (b["price_low"] + 10)) < 1e-9
+
+    def test_price_min_max_from_trades(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        assert r["price_min"] == 100.0
+        assert r["price_max"] == 120.0
+
+    def test_auto_bin_size_computed_from_range(self):
+        trades = [_trade(100, 10_000), _trade(200, 20_000)]
+        r = _run(trades, n_bins=10)
+        # range=100, n_bins=10 → bin_size=10
+        assert abs(r["bin_size"] - 10.0) < 1e-9
+
+    def test_only_non_empty_bins_returned(self):
+        # Trades at 100 and 200 with bin_size=10 → bins 0 and 10, no in-between
+        trades = [_trade(100, 10_000), _trade(200, 20_000)]
+        r = _run(trades, bin_size=10)
+        assert r["non_empty_bins"] == 2
+        assert len(r["bins"]) == 2
+
+
+# ── TestAggregation ───────────────────────────────────────────────────────────
+
+class TestAggregation:
+    def test_total_usd_is_buy_plus_sell(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        for b in r["bins"]:
+            assert abs(b["total_usd"] - (b["buy_usd"] + b["sell_usd"])) < 1
+
+    def test_buy_usd_only_buy_side(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert abs(bin0["buy_usd"] - 10_000) < 1
+
+    def test_sell_usd_only_sell_side(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert abs(bin0["sell_usd"] - 5_000) < 1
+
+    def test_count_equals_buy_count_plus_sell_count(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        for b in r["bins"]:
+            assert b["count"] == b["buy_count"] + b["sell_count"]
+
+    def test_trade_count_total(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        assert r["trade_count"] == 5
+
+    def test_total_usd_result_sum(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        expected = 10_000 + 5_000 + 30_000 + 10_000 + 8_000
+        assert abs(r["total_usd"] - expected) < 1
+
+    def test_bin1_has_correct_totals(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        bin1 = next(b for b in r["bins"] if b["price_low"] == 110.0)
+        assert abs(bin1["total_usd"] - 40_000) < 1
+        assert abs(bin1["buy_usd"]   - 30_000) < 1
+        assert abs(bin1["sell_usd"]  - 10_000) < 1
+        assert bin1["count"] == 2
+
+
+# ── TestZoneDetection ─────────────────────────────────────────────────────────
+
+class TestZoneDetection:
+    def test_dominant_bin_is_zone(self):
+        # zone_sigma=0 → threshold=mean; bin1(40k) > mean(21k) → zone
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=0)
+        bin1 = next(b for b in r["bins"] if b["price_low"] == 110.0)
+        assert bin1["is_zone"] is True
+
+    def test_smaller_bins_not_zones(self):
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=0)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        bin2 = next(b for b in r["bins"] if b["price_low"] == 120.0)
+        assert bin0["is_zone"] is False
+        assert bin2["is_zone"] is False
+
+    def test_uniform_bins_no_zones(self):
+        # All bins at same volume → std=0 → threshold=mean → strict > → no zones
+        trades = [
+            _trade(100, 10_000), _trade(110, 10_000), _trade(120, 10_000),
+        ]
+        r = _run(trades, bin_size=10)
+        assert all(not b["is_zone"] for b in r["bins"])
+
+    def test_top_zone_price_is_highest_usd_zone(self):
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=0)
+        # bin1 at 110 is the only zone (mid = 115)
+        assert abs(r["top_zone_price"] - 115.0) < 1e-6
+
+    def test_top_zone_price_none_when_no_zones(self):
+        trades = [_trade(100, 10_000), _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        assert r["top_zone_price"] is None
+
+    def test_zones_list_contains_zone_mids(self):
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=0)
+        assert 115.0 in r["zones"]  # bin1 mid = 110 + 10/2 = 115
+
+    def test_zones_list_empty_when_no_zones(self):
+        trades = [_trade(100, 10_000), _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        assert r["zones"] == []
+
+    def test_zone_sigma_zero_uses_mean_as_threshold(self):
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=0)
+        # threshold = mean of ALL bins (3 bins here, all non-empty)
+        expected_mean = (15_000 + 40_000 + 8_000) / 3
+        assert abs(r["zone_threshold_usd"] - expected_mean) < 1
+
+    def test_high_zone_sigma_produces_no_zones(self):
+        r = _run(TRADES_3BIN, bin_size=10, zone_sigma=100)
+        assert r["zones"] == []
+        assert all(not b["is_zone"] for b in r["bins"])
+
+    def test_multiple_zones_returned(self):
+        # Two dominant bins, one tiny
+        trades = [
+            _trade(100, 50_000), _trade(110, 50_000),
+            _trade(120,    100),
+        ]
+        r = _run(trades, bin_size=10, zone_sigma=0)
+        zone_bins = [b for b in r["bins"] if b["is_zone"]]
+        assert len(zone_bins) == 2
+
+
+# ── TestDominance ─────────────────────────────────────────────────────────────
+
+class TestDominance:
+    def test_buy_dominant(self):
+        trades = [_trade(100, 30_000, "buy"), _trade(100, 10_000, "sell"),
+                  _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert bin0["dominance"] == "buy"
+
+    def test_sell_dominant(self):
+        trades = [_trade(100, 10_000, "buy"), _trade(100, 30_000, "sell"),
+                  _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert bin0["dominance"] == "sell"
+
+    def test_neutral_when_equal(self):
+        trades = [_trade(100, 10_000, "buy"), _trade(100, 10_000, "sell"),
+                  _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert bin0["dominance"] == "neutral"
+
+    def test_buy_only_is_buy(self):
+        trades = [_trade(100, 50_000, "buy"), _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert bin0["dominance"] == "buy"
+
+    def test_sell_only_is_sell(self):
+        trades = [_trade(100, 50_000, "sell"), _trade(110, 10_000)]
+        r = _run(trades, bin_size=10)
+        bin0 = next(b for b in r["bins"] if b["price_low"] == 100.0)
+        assert bin0["dominance"] == "sell"
+
+
+# ── TestEdgeCases ─────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_empty_trades_safe_return(self):
+        r = _run([])
+        assert r["trade_count"] == 0
+        assert r["bins"] == []
+        assert r["zones"] == []
+        assert r["top_zone_price"] is None
+
+    def test_single_trade(self):
+        r = _run([_trade(100, 50_000)])
+        assert r["trade_count"] == 1
+        assert len(r["bins"]) == 1
+        assert r["non_empty_bins"] == 1
+
+    def test_all_trades_same_price(self):
+        trades = [_trade(100, 10_000), _trade(100, 20_000), _trade(100, 30_000)]
+        r = _run(trades, bin_size=10)
+        assert len(r["bins"]) == 1
+        assert r["bins"][0]["count"] == 3
+        assert r["top_zone_price"] is None  # single bin, std=0, no zone
+
+    def test_two_bins_only(self):
+        trades = [_trade(100, 10_000), _trade(200, 10_000)]
+        r = _run(trades, bin_size=10)
+        assert r["non_empty_bins"] == 2
+        assert isinstance(r["bins"], list)
+
+    def test_custom_bin_size_respected(self):
+        trades = [_trade(100, 10_000), _trade(101, 20_000)]
+        r_small = _run(trades, bin_size=1)   # 2 separate bins
+        r_big   = _run(trades, bin_size=10)  # both in same bin
+        assert r_small["non_empty_bins"] == 2
+        assert r_big["non_empty_bins"] == 1
+
+    def test_non_empty_bins_count_correct(self):
+        r = _run(TRADES_3BIN, bin_size=10)
+        assert r["non_empty_bins"] == 3


### PR DESCRIPTION
## Summary
- Groups whale trades by price level over 30m window, detects concentration zones
- `compute_whale_clustering()` pure function with floor-based binning and mean+σ zone detection
- `GET /api/whale-clustering` endpoint with configurable `window`, `bin_size`, `n_bins`, `zone_sigma`, `min_whale_usd`
- Frontend heatmap card: per-bin colored bars (buy=green, sell=red, zone=amber), zone badge, top zone price

## Test plan
- [ ] 53 unit tests across TestStructure, TestBinning, TestAggregation, TestZoneDetection, TestDominance, TestEdgeCases
- [ ] `pytest tests/test_whale_clustering.py -q` → 53 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)