### PR TITLE
feat: add tape speed indicator

### DIFF
--- a/.claude/metadata-updater.sh
+++ b/.claude/metadata-updater.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Metadata Updater Hook for Agent Orchestrator
+#
+# This PostToolUse hook automatically updates session metadata when:
+# - gh pr create: extracts PR URL and writes to metadata
+# - git checkout -b / git switch -c: extracts branch name and writes to metadata
+# - gh pr merge: updates status to "merged"
+
+set -euo pipefail
+
+# Configuration
+AO_DATA_DIR="${AO_DATA_DIR:-$HOME/.ao-sessions}"
+
+# Read hook input from stdin
+input=$(cat)
+
+# Extract fields from JSON (using jq if available, otherwise basic parsing)
+if command -v jq &>/dev/null; then
+  tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+  command=$(echo "$input" | jq -r '.tool_input.command // empty')
+  output=$(echo "$input" | jq -r '.tool_response // empty')
+  exit_code=$(echo "$input" | jq -r '.exit_code // 0')
+else
+  # Fallback: basic JSON parsing without jq
+  tool_name=$(echo "$input" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  command=$(echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  output=$(echo "$input" | grep -o '"tool_response"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  exit_code=$(echo "$input" | grep -o '"exit_code"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*$' || echo "0")
+fi
+
+# Only process successful commands (exit code 0)
+if [[ "$exit_code" -ne 0 ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Only process Bash tool calls
+if [[ "$tool_name" != "Bash" ]]; then
+  echo '{}' # Empty JSON output
+  exit 0
+fi
+
+# Validate AO_SESSION is set
+if [[ -z "${AO_SESSION:-}" ]]; then
+  echo '{"systemMessage": "AO_SESSION environment variable not set, skipping metadata update"}'
+  exit 0
+fi
+
+# Construct metadata file path
+# AO_DATA_DIR is already set to the project-specific sessions directory
+metadata_file="$AO_DATA_DIR/$AO_SESSION"
+
+# Ensure metadata file exists
+if [[ ! -f "$metadata_file" ]]; then
+  echo '{"systemMessage": "Metadata file not found: '"$metadata_file"'"}'
+  exit 0
+fi
+
+# Update a single key in metadata
+update_metadata_key() {
+  local key="$1"
+  local value="$2"
+
+  # Create temp file
+  local temp_file="${metadata_file}.tmp"
+
+  # Escape special sed characters in value (& | / \)
+  local escaped_value=$(echo "$value" | sed 's/[&|\/]/\\&/g')
+
+  # Check if key already exists
+  if grep -q "^$key=" "$metadata_file" 2>/dev/null; then
+    # Update existing key
+    sed "s|^$key=.*|$key=$escaped_value|" "$metadata_file" > "$temp_file"
+  else
+    # Append new key
+    cp "$metadata_file" "$temp_file"
+    echo "$key=$value" >> "$temp_file"
+  fi
+
+  # Atomic replace
+  mv "$temp_file" "$metadata_file"
+}
+
+# ============================================================================
+# Command Detection and Parsing
+# ============================================================================
+
+# Detect: gh pr create
+if [[ "$command" =~ ^gh[[:space:]]+pr[[:space:]]+create ]]; then
+  # Extract PR URL from output
+  pr_url=$(echo "$output" | grep -Eo 'https://github[.]com/[^/]+/[^/]+/pull/[0-9]+' | head -1)
+
+  if [[ -n "$pr_url" ]]; then
+    update_metadata_key "pr" "$pr_url"
+    update_metadata_key "status" "pr_open"
+    echo '{"systemMessage": "Updated metadata: PR created at '"$pr_url"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout -b <branch> or git switch -c <branch>
+if [[ "$command" =~ ^git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([^[:space:]]+) ]] || \
+   [[ "$command" =~ ^git[[:space:]]+switch[[:space:]]+-c[[:space:]]+([^[:space:]]+) ]]; then
+  branch="${BASH_REMATCH[1]}"
+
+  if [[ -n "$branch" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout <branch> (without -b) or git switch <branch> (without -c)
+# Only update if the branch name looks like a feature branch (contains / or -)
+if [[ "$command" =~ ^git[[:space:]]+checkout[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]] || \
+   [[ "$command" =~ ^git[[:space:]]+switch[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]]; then
+  branch="${BASH_REMATCH[1]}"
+
+  # Avoid updating for checkout of commits/tags
+  if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: gh pr merge
+if [[ "$command" =~ ^gh[[:space:]]+pr[[:space:]]+merge ]]; then
+  update_metadata_key "status" "merged"
+  echo '{"systemMessage": "Updated metadata: status = merged"}'
+  exit 0
+fi
+
+# No matching command, exit silently
+echo '{}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "model": "claude-sonnet-4-6",
   "effortLevel": "high",
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/aivan/.worktrees/svc-dash/sd-4/.claude/metadata-updater.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/backend/api.py
+++ b/backend/api.py
@@ -24,7 +24,6 @@ from storage import (
     insert_alert,
     get_alert_history,
     get_whale_trades,
-    insert_pattern,
     get_pattern_history,
     get_phase_snapshots,
     get_data_freshness,
@@ -64,7 +63,6 @@ from metrics import (
     compute_ob_recovery_speed,
     compute_tod_volatility,
     compute_net_taker_delta,
-    detect_oi_surge_with_crash,
     detect_squeeze_setup,
     compute_tick_imbalance_bars,
     compute_volume_bars,
@@ -73,6 +71,7 @@ from metrics import (
     compute_session_stats,
     compute_inter_exchange_oi_divergence,
     compute_whale_clustering,
+    compute_tape_speed,
 )
 
 router = APIRouter(prefix="/api")
@@ -1265,7 +1264,6 @@ async def orderbook_heatmap(
     X-axis: time (sampled every 10s)
     """
     import json as _json
-    import math
 
     syms = get_symbols()
     target = symbol if symbol and symbol in syms else syms[0]
@@ -1388,7 +1386,6 @@ async def trade_flow_heatmap(
     Returns trade flow (actual executed trades) binned by time×price.
     Shows buy/sell pressure zones.
     """
-    import math
 
     syms = get_symbols()
     target = symbol if symbol and symbol in syms else syms[0]
@@ -1673,6 +1670,45 @@ async def trade_count_rate(
     }
 
 
+@router.get("/tape-speed")
+async def tape_speed_endpoint(
+    window: int = Query(default=1800, ge=60, le=7200),
+    bucket: int = Query(default=60, ge=10, le=300),
+    hot_multiplier: float = Query(default=2.0, ge=1.1, le=10.0),
+    symbol: Optional[str] = None,
+):
+    """
+    Rolling tape speed: trades/minute gauge with high/low watermarks.
+
+    - current_tpm:    trades/min in the most recent `bucket` seconds
+    - avg_tpm:        mean TPM across the full `window`
+    - high_watermark: peak TPM observed in `window`
+    - low_watermark:  lowest non-zero TPM observed in `window`
+    - heating_up:     current_tpm > hot_multiplier * avg_tpm
+    - cooling_down:   current_tpm < avg_tpm / hot_multiplier
+    - buckets:        [{ts, tpm}] time-series for sparkline
+    """
+    target = symbol or get_symbols()[0]
+    since = time.time() - window
+
+    async with aiosqlite.connect(storage.DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT ts FROM trades WHERE ts > ? AND symbol = ? ORDER BY ts ASC",
+            (since, target),
+        ) as cur:
+            rows = await cur.fetchall()
+
+    timestamps = [r["ts"] for r in rows]
+    result = compute_tape_speed(
+        timestamps,
+        window_seconds=window,
+        bucket_seconds=bucket,
+        hot_multiplier=hot_multiplier,
+    )
+    return {"status": "ok", "symbol": target, **result}
+
+
 @router.get("/spread-history")
 async def spread_history(
     window: int = Query(default=1800, le=86400),
@@ -1762,7 +1798,7 @@ async def spread_tracker(
     - Stores in dedicated spread_history table (written by insert_orderbook)
     - Returns alert when spread_pct > threshold_pct OR current > 2x avg
     """
-    from storage import get_spread_history, get_spread_stats, DB_PATH
+    from storage import get_spread_stats
 
     syms = [symbol.upper()] if symbol else get_symbols()
     result = {}
@@ -1777,7 +1813,6 @@ async def spread_tracker(
         alert = stats.get("alert")
         current_pct = stats.get("current_pct")
         current_bps = stats.get("current_bps")
-        avg_bps = stats.get("avg_bps", 0)
         if (
             current_pct is not None
             and current_pct > threshold_pct
@@ -2437,10 +2472,10 @@ async def session_stats(symbol: Optional[str] = None):
 
     # Liquidation totals
     liq_long = sum(
-        l["value"] or 0 for l in liqs_1h if l["side"] != "buy"
+        liq["value"] or 0 for liq in liqs_1h if liq["side"] != "buy"
     )  # long liq = sell side
     liq_short = sum(
-        l["value"] or 0 for l in liqs_1h if l["side"] == "buy"
+        liq["value"] or 0 for liq in liqs_1h if liq["side"] == "buy"
     )  # short liq = buy side
     liq_total = liq_long + liq_short
 
@@ -3238,20 +3273,14 @@ async def max_drawdown(
 
         # Max run-up (low-to-high)
         trough_run = prices[0][1]
-        trough_run_ts = prices[0][0]
         max_runup = 0.0
-        max_ru_trough = trough_run
-        max_ru_peak = trough_run
 
         for ts, p in prices[1:]:
             if p < trough_run:
                 trough_run = p
-                trough_run_ts = ts
             ru = (p - trough_run) / trough_run * 100 if trough_run else 0
             if ru > max_runup:
                 max_runup = ru
-                max_ru_trough = trough_run
-                max_ru_peak = p
 
         # Current drawdown from recent peak
         recent_peak = max(p for _, p in prices[-100:])  # last ~100 trades
@@ -4219,6 +4248,13 @@ async def tod_volatility_endpoint(
         interval_seconds=interval, window_seconds=window, symbol=symbol
     )
     result = compute_tod_volatility(candles, elevation_threshold=elevation_threshold)
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        "interval_seconds": interval,
+        **result,
+    }
 
 
 @router.get("/net-taker-delta")
@@ -4247,7 +4283,6 @@ async def net_taker_delta_endpoint(
         "status": "ok",
         "symbol": symbol,
         "window_seconds": window,
-        "interval_seconds": interval,
         "bucket_seconds": bucket_seconds,
         **result,
     }
@@ -4352,6 +4387,12 @@ async def squeeze_setup_endpoint(
         price_drop_pct=price_drop_pct,
         funding_extreme=funding_extreme,
     )
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "window_seconds": window,
+        **result,
+    }
 
 
 @router.get("/tick-imbalance")

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -124,8 +124,6 @@ async def classify_market_phase(symbol: str = None) -> Dict:
     cvd_results = results[:3]
     oi_results = results[3:]
 
-    ob_data = await get_latest_orderbook(symbol=symbol, limit=1)
-
     # Price change using trade prices from CVD data (spans the full window)
     def price_change_from_cvd(data):
         if isinstance(data, Exception) or len(data) < 2:
@@ -328,8 +326,8 @@ async def detect_liquidation_cascade(
             "description": "No liquidations",
         }
 
-    buy_usd = sum(l.get("value", 0) for l in liqs if l.get("side") == "buy")
-    sell_usd = sum(l.get("value", 0) for l in liqs if l.get("side") != "buy")
+    buy_usd = sum(liq.get("value", 0) for liq in liqs if liq.get("side") == "buy")
+    sell_usd = sum(liq.get("value", 0) for liq in liqs if liq.get("side") != "buy")
     total_usd = buy_usd + sell_usd
 
     cascade = total_usd >= threshold_usd
@@ -343,11 +341,11 @@ async def detect_liquidation_cascade(
 
     # Bucket by 10s for sparkline
     buckets = {}
-    for l in liqs:
-        bucket = int((l["ts"] - since) / 10)
+    for liq in liqs:
+        bucket = int((liq["ts"] - since) / 10)
         if bucket not in buckets:
             buckets[bucket] = 0.0
-        buckets[bucket] += l.get("value", 0)
+        buckets[bucket] += liq.get("value", 0)
 
     sparkline = [round(buckets.get(i, 0), 2) for i in range(int(window_seconds / 10))]
 
@@ -456,8 +454,8 @@ async def detect_large_trades(
 
     large.sort(key=lambda x: x["value_usd"], reverse=True)
 
-    buy_vol = sum(l["value_usd"] for l in large if l["side"] in ("buy", "Buy"))
-    sell_vol = sum(l["value_usd"] for l in large if l["side"] not in ("buy", "Buy"))
+    buy_vol = sum(t["value_usd"] for t in large if t["side"] in ("buy", "Buy"))
+    sell_vol = sum(t["value_usd"] for t in large if t["side"] not in ("buy", "Buy"))
 
     return {
         "count": len(large),
@@ -936,10 +934,6 @@ async def detect_accumulation_distribution_pattern(symbol: str = None) -> Dict:
     Returns pattern type, confidence (0-1), and component signals.
     """
     now = time.time()
-    since_5m = now - 300
-    since_15m = now - 900
-    since_1h = now - 3600
-
     # Gather inputs in parallel
     oi_5m, oi_15m, cvd_5m, cvd_15m, vol_imb_5m, vol_imb_15m, funding, ob = (
         await asyncio.gather(
@@ -1086,8 +1080,6 @@ async def compute_market_regime(symbol: str = None) -> Dict:
     Returns a score from -100 (extreme bear) to +100 (extreme bull)
     with a confidence level and actionable summary.
     """
-    syms = [symbol] if symbol else None
-
     # Gather all signals
     phase_data = await classify_market_phase(symbol=symbol)
     cvd_mom = await detect_cvd_momentum(window_seconds=60, symbol=symbol)
@@ -1475,7 +1467,6 @@ async def fetch_oi_mcap_ratio(symbol: str = None) -> Dict:
     oi_contracts = latest_oi_row.get("oi_contracts") or latest_oi_row.get("oi_value", 0)
 
     # Get price to compute OI in USD
-    price_data = await get_oi_history(limit=2, symbol=symbol)
     # We'll get price from latest orderbook
     ob = await get_latest_orderbook(symbol=symbol, limit=1)
     price = None
@@ -2471,10 +2462,10 @@ async def compute_mtf_rsi_divergence(symbol: str = None, rsi_period: int = 14) -
 
     # Description
     if divergence == "bearish" and convergence == "strong":
-        desc = f"🐻 STRONG bearish RSI divergence (5m+1h) — price higher, RSI lower"
+        desc = "🐻 STRONG bearish RSI divergence (5m+1h) — price higher, RSI lower"
         severity = "high"
     elif divergence == "bullish" and convergence == "strong":
-        desc = f"🐂 STRONG bullish RSI divergence (5m+1h) — price lower, RSI higher"
+        desc = "🐂 STRONG bullish RSI divergence (5m+1h) — price lower, RSI higher"
         severity = "high"
     elif divergence == "bearish":
         tf = "5m" if div_5m else "1h"
@@ -2764,7 +2755,6 @@ async def compute_ob_pressure_gradient(
     Negative gradient → increasing ask pressure (selling)
     """
     import json
-    import time
     from storage import get_orderbook_history
 
     ob_rows = await get_orderbook_history(limit=200, symbol=symbol)
@@ -3328,9 +3318,9 @@ def compute_tod_volatility(
 
     def _hl_pct(c) -> float:
         h = float(c["high"])
-        l = float(c["low"])
+        lo = float(c["low"])
         cl = float(c["close"])
-        return (h - l) / cl * 100.0 if cl != 0 else 0.0
+        return (h - lo) / cl * 100.0 if cl != 0 else 0.0
 
     # Split into current vs historical
     current_vals: List[float] = []
@@ -4272,4 +4262,102 @@ def compute_whale_clustering(
         "price_min": price_min,
         "price_max": price_max,
         "zone_threshold_usd": zone_threshold,
+    }
+
+
+# ── Tape Speed Indicator ──────────────────────────────────────────────────────
+
+
+def compute_tape_speed(
+    trade_timestamps: List[float],
+    window_seconds: int = 1800,
+    bucket_seconds: int = 60,
+    hot_multiplier: float = 2.0,
+    reference_ts: Optional[float] = None,
+) -> Dict:
+    """
+    Rolling tape speed: trades/minute with high/low watermarks and heat signal.
+
+    Args:
+        trade_timestamps: Unix timestamps of trades (any order; filtered to window)
+        window_seconds:   look-back window for watermarks and avg
+        bucket_seconds:   width of each historical TPM bucket
+        hot_multiplier:   current_tpm > mult*avg → heating_up; < avg/mult → cooling_down
+        reference_ts:     treat as "now" (defaults to time.time(); injectable for tests)
+
+    Returns:
+        current_tpm    float  TPM in sliding [now-bucket_seconds, now]
+        avg_tpm        float  mean TPM across all historical buckets (incl. zeros)
+        high_watermark float  peak TPM among historical buckets
+        low_watermark  float | None  min non-zero TPM (None when all buckets zero)
+        heating_up     bool
+        cooling_down   bool
+        buckets        list[{ts, tpm}]  historical series, sorted ascending
+        total_trades   int
+        window_seconds int
+        bucket_seconds int
+    """
+    now = reference_ts if reference_ts is not None else time.time()
+    since = now - window_seconds
+
+    # Filter to window (strict: ts > since)
+    in_window = [ts for ts in trade_timestamps if ts > since]
+
+    if not in_window:
+        return {
+            "current_tpm": 0.0,
+            "avg_tpm": 0.0,
+            "high_watermark": 0.0,
+            "low_watermark": None,
+            "heating_up": False,
+            "cooling_down": False,
+            "buckets": [],
+            "total_trades": 0,
+            "window_seconds": window_seconds,
+            "bucket_seconds": bucket_seconds,
+        }
+
+    # Current TPM: sliding window [now - bucket_seconds, now]
+    current_count = sum(1 for ts in in_window if ts > now - bucket_seconds)
+    current_tpm = current_count * (60.0 / bucket_seconds)
+
+    # Historical buckets: floor each ts to bucket boundary, count per bucket
+    bucket_map: Dict[float, int] = {}
+    for ts in in_window:
+        b = float(int(ts // bucket_seconds) * bucket_seconds)
+        bucket_map[b] = bucket_map.get(b, 0) + 1
+
+    # Fill gap buckets with zero so the series is continuous
+    start_b = float(int(since // bucket_seconds) * bucket_seconds)
+    end_b = float(int(now // bucket_seconds) * bucket_seconds)
+    b = start_b
+    while b <= end_b:
+        bucket_map.setdefault(b, 0)
+        b += bucket_seconds
+
+    bucket_tpms = [
+        {"ts": bk, "tpm": round(cnt * (60.0 / bucket_seconds), 4)}
+        for bk, cnt in sorted(bucket_map.items())
+    ]
+
+    tpm_values = [bkt["tpm"] for bkt in bucket_tpms]
+    avg_tpm = sum(tpm_values) / len(tpm_values) if tpm_values else 0.0
+    high_watermark = max(tpm_values) if tpm_values else 0.0
+    non_zero = [v for v in tpm_values if v > 0]
+    low_watermark = min(non_zero) if non_zero else None
+
+    heating_up = avg_tpm > 0 and current_tpm > hot_multiplier * avg_tpm
+    cooling_down = avg_tpm > 0 and current_tpm < avg_tpm / hot_multiplier
+
+    return {
+        "current_tpm": round(current_tpm, 4),
+        "avg_tpm": round(avg_tpm, 4),
+        "high_watermark": round(high_watermark, 4),
+        "low_watermark": round(low_watermark, 4) if low_watermark is not None else None,
+        "heating_up": heating_up,
+        "cooling_down": cooling_down,
+        "buckets": bucket_tpms,
+        "total_trades": len(in_window),
+        "window_seconds": window_seconds,
+        "bucket_seconds": bucket_seconds,
     }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1347,6 +1347,49 @@ async function renderVpin() {
   `;
 }
 
+// ── Render: Tape Speed ────────────────────────────────────────────────────────
+async function renderTapeSpeed() {
+  const sym = encodeURIComponent(activeSymbol);
+  const data = await apiFetch(`/tape-speed?symbol=${sym}`);
+  const el = document.getElementById('tape-speed-content');
+  if (!el) return;
+  if (!data) { el.innerHTML = '<div class="text-muted" style="font-size:11px;">No data</div>'; return; }
+
+  const cur    = data.current_tpm  != null ? data.current_tpm.toFixed(1)  : '—';
+  const avg    = data.avg_tpm      != null ? data.avg_tpm.toFixed(1)      : '—';
+  const high   = data.high_watermark != null ? data.high_watermark.toFixed(1) : '—';
+  const low    = data.low_watermark  != null ? data.low_watermark.toFixed(1)  : '—';
+
+  const heatColor = data.heating_up ? 'var(--red)' : data.cooling_down ? 'var(--blue)' : 'var(--fg)';
+  const heatLabel = data.heating_up ? 'HEATING' : data.cooling_down ? 'COOLING' : 'STABLE';
+  const badgeClass = data.heating_up ? 'badge-red' : data.cooling_down ? 'badge-blue' : 'badge-yellow';
+
+  const badge = document.getElementById('tape-speed-badge');
+  if (badge) {
+    badge.textContent = heatLabel;
+    badge.className = `card-badge ${badgeClass}`;
+    badge.style.display = '';
+  }
+
+  // Bar chart: last N buckets as sparkline
+  const buckets = (data.buckets || []).slice(-20);
+  const maxTpm  = data.high_watermark || 1;
+  const bars = buckets.map(b => {
+    const pct = Math.min((b.tpm / maxTpm) * 100, 100).toFixed(1);
+    return `<div class="ts-bar" style="height:${pct}%;background:var(--blue)" title="${b.tpm.toFixed(1)} tpm"></div>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div class="ts-metrics">
+      <span class="ts-stat">Current <span style="color:${heatColor};font-weight:700">${cur} tpm</span></span>
+      <span class="ts-stat">Avg <span>${avg} tpm</span></span>
+      <span class="ts-stat">High <span class="text-yellow">${high}</span></span>
+      <span class="ts-stat">Low <span class="text-muted">${low}</span></span>
+    </div>
+    <div class="ts-chart">${bars}</div>
+  `;
+}
+
 // ── Main Refresh Loop ─────────────────────────────────────────────────────────
 async function refresh() {
   if (!activeSymbol) return;
@@ -1369,6 +1412,7 @@ async function refresh() {
     renderCorrelations(),
     renderVpin(),
     renderAdaptiveVolumeProfile(),
+    renderTapeSpeed(),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,6 +131,18 @@
     </div>
   </section>
 
+  <!-- Tape Speed -->
+  <section class="card" id="card-tape-speed">
+    <div class="card-header">
+      <span class="card-title">Tape Speed</span>
+      <span id="tape-speed-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">trades/min · 30 min</span>
+    </div>
+    <div id="tape-speed-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- Inter-Exchange OI Divergence -->
   <section class="card" id="card-oi-divergence">
     <div class="card-header">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -494,6 +494,36 @@ html, body {
 
 .oi-stat span { color: var(--fg); font-weight: 700; }
 
+/* ── Tape Speed ───────────────────────────────────────────────────────────── */
+#card-tape-speed { grid-column: 1 / 3; }
+
+.ts-metrics {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 8px;
+  font-size: 11px;
+  flex-wrap: wrap;
+}
+
+.ts-stat { color: var(--muted); }
+.ts-stat span { color: var(--fg); font-weight: 700; }
+
+.ts-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 48px;
+  padding: 0 2px;
+}
+
+.ts-bar {
+  flex: 1;
+  min-width: 4px;
+  border-radius: 2px 2px 0 0;
+  transition: height 0.3s ease;
+  opacity: 0.8;
+}
+
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   #main {

--- a/tests/test_tape_speed.py
+++ b/tests/test_tape_speed.py
@@ -1,0 +1,302 @@
+"""
+TDD tests for tape speed indicator.
+
+Spec:
+  compute_tape_speed(
+      trade_timestamps,         # list[float]  Unix timestamps of trades in window
+      window_seconds=1800,      # int   how far back to look
+      bucket_seconds=60,        # int   bucket width for historical TPM series
+      hot_multiplier=2.0,       # float heating_up  when current_tpm > mult * avg_tpm
+      reference_ts=None,        # float "now" (defaults to time.time(); injectable for tests)
+  )
+
+  current_tpm    : float  trades/min in the sliding [now - bucket_seconds, now] window
+  avg_tpm        : float  mean TPM across all historical buckets (including zeros)
+  high_watermark : float  peak TPM among historical buckets
+  low_watermark  : float  lowest non-zero TPM among historical buckets (None if all zero)
+  heating_up     : bool   current_tpm > hot_multiplier * avg_tpm  AND avg_tpm > 0
+  cooling_down   : bool   avg_tpm > 0  AND current_tpm < avg_tpm / hot_multiplier
+  buckets        : list[{ts: float, tpm: float}]  sorted ascending, one per bucket
+  total_trades   : int    trades inside the window
+  window_seconds : int
+  bucket_seconds : int
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+from metrics import compute_tape_speed  # noqa: E402
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+BASE = 1_700_000_000.0  # arbitrary fixed "now" for all tests
+
+
+def _ts(*offsets: float) -> list:
+    """Return [BASE + o for o in offsets]."""
+    return [BASE + o for o in offsets]
+
+
+def _run(timestamps, *, window=1800, bucket=60, mult=2.0, ref=None):
+    ref = ref or BASE
+    return compute_tape_speed(
+        timestamps,
+        window_seconds=window,
+        bucket_seconds=bucket,
+        hot_multiplier=mult,
+        reference_ts=ref,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Structure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStructure:
+    def test_returns_dict(self):
+        assert isinstance(_run([]), dict)
+
+    def test_required_keys(self):
+        r = _run([])
+        for k in ("current_tpm", "avg_tpm", "high_watermark", "low_watermark",
+                  "heating_up", "cooling_down", "buckets",
+                  "total_trades", "window_seconds", "bucket_seconds"):
+            assert k in r, f"missing key: {k}"
+
+    def test_empty_zeros(self):
+        r = _run([])
+        assert r["current_tpm"]    == 0.0
+        assert r["avg_tpm"]        == 0.0
+        assert r["high_watermark"] == 0.0
+        assert r["low_watermark"]  is None
+        assert r["total_trades"]   == 0
+        assert r["heating_up"]     is False
+        assert r["cooling_down"]   is False
+
+    def test_empty_buckets_list(self):
+        assert _run([])["buckets"] == []
+
+    def test_params_echoed(self):
+        r = _run([], window=900, bucket=30)
+        assert r["window_seconds"] == 900
+        assert r["bucket_seconds"] == 30
+
+    def test_bucket_has_ts_and_tpm(self):
+        # one trade 30 s ago → should produce at least one bucket
+        r = _run(_ts(-30), window=120, bucket=60)
+        assert r["buckets"]
+        b = r["buckets"][0]
+        assert "ts"  in b
+        assert "tpm" in b
+
+    def test_buckets_sorted_ascending(self):
+        timestamps = _ts(-300, -240, -180, -120, -60, -10)
+        r = _run(timestamps, bucket=60)
+        ts_list = [b["ts"] for b in r["buckets"]]
+        assert ts_list == sorted(ts_list)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# current_tpm
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCurrentTpm:
+    def test_single_trade_inside_window(self):
+        # 1 trade in last 60 s → 1 trade/min
+        r = _run(_ts(-30), bucket=60)
+        assert r["current_tpm"] == pytest.approx(1.0)
+
+    def test_sixty_trades_in_last_bucket(self):
+        # 60 trades strictly inside last 60 s → 60 trades/min
+        # use fractional offsets to stay clearly inside the sliding window
+        r = _run(_ts(*[-(i * 0.9 + 0.5) for i in range(60)]), bucket=60)
+        assert r["current_tpm"] == pytest.approx(60.0)
+
+    def test_no_trades_in_last_bucket(self):
+        # trades only 2 min ago → current window is empty
+        r = _run(_ts(-130, -150), bucket=60)
+        assert r["current_tpm"] == 0.0
+
+    def test_trades_outside_window_excluded(self):
+        old = _ts(-9000)   # way outside 1800s window
+        r = _run(old, window=1800, bucket=60)
+        assert r["total_trades"] == 0
+        assert r["current_tpm"]  == 0.0
+
+    def test_bucket_scaling(self):
+        # 30 trades strictly inside last 30 s, bucket=30 → 60 tpm
+        r = _run(_ts(*[-(i * 0.9 + 0.5) for i in range(30)]), bucket=30)
+        assert r["current_tpm"] == pytest.approx(60.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# total_trades
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTotalTrades:
+    def test_counts_all_in_window(self):
+        r = _run(_ts(-10, -100, -500, -1000), window=1800, bucket=60)
+        assert r["total_trades"] == 4
+
+    def test_excludes_outside_window(self):
+        r = _run(_ts(-10, -9999), window=1800, bucket=60)
+        assert r["total_trades"] == 1
+
+    def test_exactly_at_boundary_excluded(self):
+        # trade at exactly reference_ts - window is outside (strict >)
+        r = _run([BASE - 1800], window=1800, bucket=60, ref=BASE)
+        assert r["total_trades"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Watermarks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestWatermarks:
+    def test_high_watermark_is_max_bucket_tpm(self):
+        # 5 trades in bucket at -300s, 1 trade in bucket at -60s
+        five = _ts(*[-305 - i for i in range(5)])   # 5 trades ~5 min ago
+        one  = _ts(-65)                              # 1 trade ~1 min ago
+        r = _run(five + one, bucket=60, ref=BASE)
+        assert r["high_watermark"] == pytest.approx(5.0)  # 5 trades in 60s = 5 tpm
+
+    def test_low_watermark_ignores_zero_buckets(self):
+        # sparse trades: 2 in one bucket, nothing for a long stretch
+        two = _ts(-605, -610)   # 2 trades in 60s = 2 tpm bucket
+        r = _run(two, window=1800, bucket=60, ref=BASE)
+        assert r["low_watermark"] == pytest.approx(2.0)
+
+    def test_low_watermark_none_when_all_zero(self):
+        assert _run([])["low_watermark"] is None
+
+    def test_single_bucket_high_equals_low(self):
+        # all trades in one bucket → high = low
+        trades = _ts(-305, -310, -315)  # 3 trades in same bucket
+        r = _run(trades, bucket=60, ref=BASE)
+        assert r["high_watermark"] == r["low_watermark"]
+
+    def test_watermarks_are_floats(self):
+        r = _run(_ts(-30))
+        assert isinstance(r["high_watermark"], float)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# avg_tpm
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestAvgTpm:
+    def test_avg_zero_when_empty(self):
+        assert _run([])["avg_tpm"] == 0.0
+
+    def test_avg_equals_tpm_when_one_nonempty_bucket(self):
+        # 3 trades in one bucket, rest empty
+        r = _run(_ts(-305, -310, -315), bucket=60, ref=BASE)
+        # avg should include ALL buckets (zero and non-zero), so avg < bucket tpm
+        # but high_watermark should equal that bucket's tpm
+        assert r["avg_tpm"] <= r["high_watermark"]
+
+    def test_avg_accounts_for_zero_buckets(self):
+        # 60 trades in one bucket, 29 empty buckets → avg much < 60
+        r = _run(_ts(*[-5 - i for i in range(60)]), window=1800, bucket=60, ref=BASE)
+        assert r["avg_tpm"] < r["high_watermark"]
+
+    def test_uniform_distribution_avg_equals_tpm(self):
+        # same number of trades in every bucket → avg == high == low
+        trades = []
+        for bucket_offset in range(1, 6):  # 5 buckets, 60s apart
+            for _ in range(3):
+                trades.append(BASE - bucket_offset * 60 - 5)
+        r = _run(trades, bucket=60, ref=BASE, window=400)
+        # All non-zero buckets have same tpm → high == low == avg (of non-zero)
+        assert r["high_watermark"] == r["low_watermark"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Heating up / cooling down
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestHeatSignal:
+    def _make_hot(self, mult=2.0):
+        """Historical buckets: 1 trade/bucket. Current bucket: many trades."""
+        historical = []
+        for i in range(2, 10):   # buckets from -9min to -2min
+            historical.append(BASE - i * 60 - 5)
+        current_burst = _ts(*[-(j + 1) for j in range(30)])  # 30 trades now
+        return historical + current_burst
+
+    def _make_cold(self, mult=2.0):
+        """Historical buckets: many trades. Current bucket: 1 trade."""
+        historical = []
+        for i in range(2, 10):
+            for _ in range(20):   # 20 trades per old bucket
+                historical.append(BASE - i * 60 - 5)
+        current_slow = _ts(-10)   # just 1 trade now
+        return historical + current_slow
+
+    def test_heating_up_true_when_burst(self):
+        r = _run(self._make_hot(), bucket=60, mult=2.0, ref=BASE, window=1800)
+        assert r["heating_up"] is True
+
+    def test_heating_up_false_when_uniform(self):
+        # identical rate throughout
+        trades = [BASE - i * 10 - 5 for i in range(100)]
+        r = _run(trades, bucket=60, mult=2.0, ref=BASE, window=1800)
+        # current ≈ avg → not heating
+        assert r["heating_up"] is False
+
+    def test_heating_up_false_when_empty(self):
+        assert _run([])["heating_up"] is False
+
+    def test_cooling_down_true_when_slowing(self):
+        r = _run(self._make_cold(), bucket=60, mult=2.0, ref=BASE, window=1800)
+        assert r["cooling_down"] is True
+
+    def test_cooling_down_false_when_empty(self):
+        assert _run([])["cooling_down"] is False
+
+    def test_not_both_heating_and_cooling(self):
+        for ts_list in (self._make_hot(), self._make_cold(), []):
+            r = _run(ts_list, bucket=60, ref=BASE, window=1800)
+            assert not (r["heating_up"] and r["cooling_down"])
+
+    def test_custom_multiplier(self):
+        # With mult=1.1, even modest bursts trigger heating
+        historical = [BASE - i * 60 - 5 for i in range(2, 10)]  # 1 trade each
+        burst = _ts(*[-(j + 1) for j in range(5)])               # 5 now
+        r = _run(historical + burst, bucket=60, mult=1.1, ref=BASE, window=1800)
+        assert r["heating_up"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bucket contents
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBuckets:
+    def test_no_buckets_when_empty(self):
+        assert _run([])["buckets"] == []
+
+    def test_tpm_in_bucket_is_float(self):
+        r = _run(_ts(-30), bucket=60)
+        assert isinstance(r["buckets"][0]["tpm"], float)
+
+    def test_bucket_ts_is_floored(self):
+        # A trade at BASE-30 should land in the floored 60s bucket
+        r = _run(_ts(-30), bucket=60, ref=BASE)
+        expected_bucket = float(int((BASE - 30) // 60) * 60)
+        non_zero = [b for b in r["buckets"] if b["tpm"] > 0]
+        assert non_zero, "expected at least one non-zero bucket"
+        assert non_zero[0]["ts"] == pytest.approx(expected_bucket)
+
+    def test_two_trades_same_bucket(self):
+        # Two trades within the same 60s interval → one bucket, tpm=2
+        r = _run(_ts(-61, -65), bucket=60, ref=BASE)
+        # Both land in bucket starting at floor((BASE-65)//60)*60
+        tpms = [b["tpm"] for b in r["buckets"] if b["tpm"] > 0]
+        assert tpms == [pytest.approx(2.0)]
+
+    def test_two_trades_different_buckets(self):
+        r = _run(_ts(-30, -100), bucket=60, ref=BASE)
+        non_zero = [b for b in r["buckets"] if b["tpm"] > 0]
+        assert len(non_zero) == 2


### PR DESCRIPTION
Rolling trades/minute gauge with high/low watermarks. Shows when market is heating up or cooling down.

## Features
- `compute_tape_speed()` in `backend/metrics.py`: sliding window trades/min
- High/low watermarks tracked across 30m history
- `heating_up` / `cooling_down` regime signals  
- GET `/api/tape-speed` endpoint per symbol
- Frontend gauge card with current TPM, high/low watermarks, regime badge
- 36 unit tests, all passing