### PR TITLE
feat: aggressor imbalance streak counter

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -72,6 +72,7 @@ from metrics import (
     compute_inter_exchange_oi_divergence,
     compute_whale_clustering,
     compute_tape_speed,
+    compute_aggressor_imbalance_streak,
 )
 
 router = APIRouter(prefix="/api")
@@ -577,6 +578,36 @@ async def aggressor_ratio_endpoint(
     target = symbol if symbol and symbol in syms else syms[0]
     data = await compute_aggressor_ratio_series(
         symbol=target, window_seconds=window, bucket_size=bucket
+    )
+    return {"status": "ok", "symbol": target, **data}
+
+
+@router.get("/aggressor-streak")
+async def aggressor_streak_endpoint(
+    symbol: Optional[str] = None,
+    window: int = Query(default=1800, ge=300, le=14400),
+    bucket: int = Query(default=60, ge=10, le=600),
+    threshold: float = Query(default=70.0, ge=50.0, le=95.0),
+    alert_streak: int = Query(default=3, ge=2, le=20),
+):
+    """
+    Aggressor imbalance streak counter.
+
+    Counts consecutive 1-min candles where buy aggressor > threshold% or
+    sell aggressor > threshold%. Returns alert=true when streak >= alert_streak.
+    """
+    from collectors import get_symbols
+    from storage import get_recent_trades
+
+    syms = get_symbols()
+    target = symbol if symbol and symbol in syms else syms[0]
+    since = time.time() - window
+    trades = await get_recent_trades(limit=20000, since=since, symbol=target)
+    data = compute_aggressor_imbalance_streak(
+        trades,
+        bucket_size=bucket,
+        threshold_pct=threshold,
+        alert_streak=alert_streak,
     )
     return {"status": "ok", "symbol": target, **data}
 

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -4361,3 +4361,112 @@ def compute_tape_speed(
         "window_seconds": window_seconds,
         "bucket_seconds": bucket_seconds,
     }
+
+
+def compute_aggressor_imbalance_streak(
+    trades: List[Dict],
+    bucket_size: int = 60,
+    threshold_pct: float = 70.0,
+    alert_streak: int = 3,
+) -> Dict:
+    """
+    Aggressor imbalance streak counter.
+
+    Buckets trades into 1-min candles and tracks consecutive candles where
+    buy aggressor > threshold_pct% OR sell aggressor > threshold_pct%.
+    Alert fires when streak >= alert_streak (default: 3).
+
+    Args:
+        trades: list of {ts, price, qty, side} dicts
+        bucket_size: seconds per candle (default 60)
+        threshold_pct: imbalance threshold, e.g. 70 means >70% one side
+        alert_streak: number of consecutive imbalanced candles to trigger alert
+
+    Returns:
+        candles:          [{ts, buy_pct, sell_pct, total, direction}]
+        streak:           int — current consecutive streak length
+        streak_direction: "buy" | "sell" | None
+        alert:            bool — streak >= alert_streak
+        alert_streak:     int — configured alert threshold
+        description:      str — human-readable summary
+    """
+    if not trades:
+        return {
+            "candles": [],
+            "streak": 0,
+            "streak_direction": None,
+            "alert": False,
+            "alert_streak": alert_streak,
+            "description": "No data",
+        }
+
+    # Build per-candle buy/sell counts
+    buckets: Dict[int, Dict[str, int]] = {}
+    for t in trades:
+        b = int(t["ts"] // bucket_size) * bucket_size
+        side = (t.get("side") or "").lower()
+        if b not in buckets:
+            buckets[b] = {"buy": 0, "sell": 0}
+        if side == "buy":
+            buckets[b]["buy"] += 1
+        else:
+            buckets[b]["sell"] += 1
+
+    sell_threshold = 100.0 - threshold_pct
+
+    candles = []
+    for ts in sorted(buckets):
+        c = buckets[ts]
+        total = c["buy"] + c["sell"]
+        buy_pct = c["buy"] / total * 100.0 if total > 0 else 50.0
+        sell_pct = 100.0 - buy_pct
+
+        if buy_pct >= threshold_pct:
+            direction: Optional[str] = "buy"
+        elif buy_pct <= sell_threshold:
+            direction = "sell"
+        else:
+            direction = None
+
+        candles.append(
+            {
+                "ts": float(ts),
+                "buy_pct": round(buy_pct, 2),
+                "sell_pct": round(sell_pct, 2),
+                "total": total,
+                "direction": direction,
+            }
+        )
+
+    # Count trailing streak from the last candle
+    streak = 0
+    streak_direction: Optional[str] = None
+    if candles:
+        last_dir = candles[-1]["direction"]
+        if last_dir is not None:
+            streak_direction = last_dir
+            for c in reversed(candles):
+                if c["direction"] == last_dir:
+                    streak += 1
+                else:
+                    break
+
+    alert = streak >= alert_streak
+
+    if streak == 0:
+        desc = "No aggressor imbalance streak"
+    else:
+        side_label = streak_direction.upper() if streak_direction else ""
+        if alert:
+            desc = f"ALERT: {streak}-candle {side_label} aggressor streak (>= {threshold_pct:.0f}%)"
+        else:
+            desc = f"{streak}-candle {side_label} aggressor streak (>= {threshold_pct:.0f}%)"
+
+    return {
+        "candles": candles,
+        "streak": streak,
+        "streak_direction": streak_direction,
+        "alert": alert,
+        "alert_streak": alert_streak,
+        "description": desc,
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1391,6 +1391,70 @@ async function renderTapeSpeed() {
   `;
 }
 
+
+async function renderAggressorStreak() {
+  const sym = encodeURIComponent(activeSymbol);
+  const data = await apiFetch(`/aggressor-streak?symbol=${sym}`);
+  if (!data) return;
+
+  const el    = document.getElementById('aggressor-streak-content');
+  const badge = document.getElementById('aggressor-streak-badge');
+  if (!el) return;
+
+  const streak    = data.streak || 0;
+  const dir       = data.streak_direction;
+  const alert     = data.alert;
+  const threshold = data.alert_streak || 3;
+  const candles   = data.candles || [];
+  const desc      = data.description || '—';
+
+  const dirColor = dir === 'buy' ? 'var(--green)' : dir === 'sell' ? 'var(--red)' : 'var(--muted)';
+  const dirLabel = dir ? dir.toUpperCase() : '—';
+
+  if (badge) {
+    if (streak === 0) {
+      badge.textContent  = 'no streak';
+      badge.className    = 'card-badge badge-gray';
+    } else if (alert) {
+      badge.textContent  = `ALERT ${streak}x ${dirLabel}`;
+      badge.className    = 'card-badge ' + (dir === 'buy' ? 'badge-green' : 'badge-red');
+    } else {
+      badge.textContent  = `${streak}x ${dirLabel}`;
+      badge.className    = 'card-badge ' + (dir === 'buy' ? 'badge-green' : 'badge-red');
+    }
+    badge.style.display = 'inline-block';
+  }
+
+  // Last 10 candles as mini bar indicators
+  const recent = candles.slice(-10);
+  const bars = recent.map(c => {
+    const col = c.direction === 'buy' ? 'var(--green)' : c.direction === 'sell' ? 'var(--red)' : 'var(--muted)';
+    const pct = c.direction === 'buy' ? c.buy_pct.toFixed(0) : c.direction === 'sell' ? c.sell_pct.toFixed(0) : '—';
+    return `<div class="metric-box" style="border-top:3px solid ${col}">
+      <div class="metric-label">${new Date(c.ts * 1000).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}</div>
+      <div class="metric-value" style="color:${col};font-size:13px">${pct}%</div>
+    </div>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:8px">
+      <div>
+        <div style="font-size:28px;font-weight:700;color:${dirColor}">${streak}</div>
+        <div style="font-size:11px;color:var(--muted)">streak</div>
+      </div>
+      <div style="flex:1">
+        <div style="font-size:13px;color:${alert ? dirColor : 'var(--fg)'}">
+          ${alert ? '⚡ ' : ''}${desc}
+        </div>
+        <div style="font-size:11px;color:var(--muted);margin-top:2px">
+          alert at ${threshold}+ consecutive candles · 70% threshold
+        </div>
+      </div>
+    </div>
+    <div class="phase-metrics" style="flex-wrap:wrap">${bars || '<span style="color:var(--muted);font-size:11px">No candle data</span>'}</div>
+  `;
+}
+
 // ── Main Refresh Loop ─────────────────────────────────────────────────────────
 async function refresh() {
   if (!activeSymbol) return;
@@ -1415,6 +1479,7 @@ async function refresh() {
     renderAdaptiveVolumeProfile(),
     renderAggressorRatio(),
     renderTapeSpeed(),
+    renderAggressorStreak(),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -262,6 +262,18 @@
     </div>
   </section>
 
+  <!-- Aggressor Streak -->
+  <section class="card" id="card-aggressor-streak">
+    <div class="card-header">
+      <span class="card-title">Aggressor Streak</span>
+      <span id="aggressor-streak-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">consecutive imbalanced candles · 70% threshold</span>
+    </div>
+    <div id="aggressor-streak-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
 </main>
 
 <script src="app.js"></script>

--- a/tests/test_aggressor_streak.py
+++ b/tests/test_aggressor_streak.py
@@ -1,0 +1,354 @@
+"""
+TDD tests for Aggressor Imbalance Streak Counter.
+
+Pure function under test:
+
+compute_aggressor_imbalance_streak(
+    trades,                    # [{ts, price, qty, side}]
+    bucket_size=60,            # seconds per candle (default: 1m)
+    threshold_pct=70.0,        # buy% or sell% threshold for imbalance
+    alert_streak=3,            # consecutive candles to trigger alert
+)
+    - Buckets trades into time windows of bucket_size seconds
+    - For each bucket: buy_pct = buy_count / total_count * 100
+    - Candle direction: "buy" if buy_pct >= threshold_pct
+                        "sell" if buy_pct <= (100 - threshold_pct)
+                        None otherwise (balanced)
+    - Streak: count consecutive trailing candles with the same non-None direction
+    - Returns:
+        candles:           [{ts, buy_pct, sell_pct, total, direction}]
+        streak:            int   — current streak length (0 if no imbalance candle at end)
+        streak_direction:  str | None  — "buy" | "sell" | None
+        alert:             bool  — streak >= alert_streak
+        alert_streak:      int   — the configured threshold (default 3)
+        description:       str   — human-readable summary
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from metrics import compute_aggressor_imbalance_streak  # noqa: E402
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _trade(ts, side="buy", qty=1.0, price=100.0):
+    return {"ts": float(ts), "price": float(price), "qty": float(qty), "side": side}
+
+
+def _buy(ts, qty=1.0):
+    return _trade(ts, side="buy", qty=qty)
+
+
+def _sell(ts, qty=1.0):
+    return _trade(ts, side="sell", qty=qty)
+
+
+def _candle_trades(ts_start, buy_count, sell_count, bucket=60):
+    """Fill a bucket starting at ts_start with buy_count buys and sell_count sells."""
+    trades = []
+    for i in range(buy_count):
+        trades.append(_buy(ts=ts_start + i * 0.1))
+    for i in range(sell_count):
+        trades.append(_sell(ts=ts_start + buy_count * 0.1 + i * 0.1))
+    return trades
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Structure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStructure:
+    def test_empty_returns_valid_dict(self):
+        r = compute_aggressor_imbalance_streak([])
+        assert isinstance(r, dict)
+
+    def test_required_fields_present(self):
+        r = compute_aggressor_imbalance_streak([])
+        for f in ("candles", "streak", "streak_direction", "alert", "alert_streak", "description"):
+            assert f in r, f"missing field: {f}"
+
+    def test_empty_gives_zero_streak(self):
+        r = compute_aggressor_imbalance_streak([])
+        assert r["streak"] == 0
+        assert r["streak_direction"] is None
+        assert r["alert"] is False
+        assert r["candles"] == []
+
+    def test_alert_streak_field_reflects_parameter(self):
+        r = compute_aggressor_imbalance_streak([], alert_streak=5)
+        assert r["alert_streak"] == 5
+
+    def test_description_is_string(self):
+        r = compute_aggressor_imbalance_streak([])
+        assert isinstance(r["description"], str)
+
+    def test_candle_has_required_fields(self):
+        trades = _candle_trades(0, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert len(r["candles"]) == 1
+        c = r["candles"][0]
+        for f in ("ts", "buy_pct", "sell_pct", "total", "direction"):
+            assert f in c, f"missing candle field: {f}"
+
+    def test_candle_buy_pct_sell_pct_sum_to_100(self):
+        trades = _candle_trades(0, buy_count=7, sell_count=3)
+        r = compute_aggressor_imbalance_streak(trades)
+        c = r["candles"][0]
+        assert abs(c["buy_pct"] + c["sell_pct"] - 100.0) < 0.01
+
+    def test_candle_total_reflects_trade_count(self):
+        trades = _candle_trades(0, buy_count=6, sell_count=4)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["candles"][0]["total"] == 10
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bucketing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBucketing:
+    def test_single_minute_one_candle(self):
+        trades = [_buy(0), _buy(30), _sell(59)]
+        r = compute_aggressor_imbalance_streak(trades, bucket_size=60)
+        assert len(r["candles"]) == 1
+
+    def test_two_minutes_two_candles(self):
+        trades = [_buy(0), _buy(60)]
+        r = compute_aggressor_imbalance_streak(trades, bucket_size=60)
+        assert len(r["candles"]) == 2
+
+    def test_bucket_ts_is_floor_of_window(self):
+        r = compute_aggressor_imbalance_streak([_buy(45)], bucket_size=60)
+        assert r["candles"][0]["ts"] == 0.0
+
+    def test_candles_sorted_ascending_by_ts(self):
+        trades = [_buy(120), _buy(0), _buy(60)]
+        r = compute_aggressor_imbalance_streak(trades, bucket_size=60)
+        ts_vals = [c["ts"] for c in r["candles"]]
+        assert ts_vals == sorted(ts_vals)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Direction classification
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDirectionClassification:
+    def test_buy_direction_when_buy_pct_above_threshold(self):
+        """8 buys, 2 sells → 80% buy → direction=buy."""
+        trades = _candle_trades(0, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=70.0)
+        assert r["candles"][0]["direction"] == "buy"
+
+    def test_sell_direction_when_sell_pct_above_threshold(self):
+        """2 buys, 8 sells → 20% buy → direction=sell."""
+        trades = _candle_trades(0, buy_count=2, sell_count=8)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=70.0)
+        assert r["candles"][0]["direction"] == "sell"
+
+    def test_no_direction_when_balanced(self):
+        """5 buys, 5 sells → 50% buy → direction=None."""
+        trades = _candle_trades(0, buy_count=5, sell_count=5)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=70.0)
+        assert r["candles"][0]["direction"] is None
+
+    def test_exactly_at_threshold_is_buy(self):
+        """7 buys, 3 sells → exactly 70% → direction=buy."""
+        trades = _candle_trades(0, buy_count=7, sell_count=3)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=70.0)
+        assert r["candles"][0]["direction"] == "buy"
+
+    def test_exactly_at_sell_threshold_is_sell(self):
+        """3 buys, 7 sells → exactly 30% buy → direction=sell."""
+        trades = _candle_trades(0, buy_count=3, sell_count=7)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=70.0)
+        assert r["candles"][0]["direction"] == "sell"
+
+    def test_custom_threshold(self):
+        """6 buys, 4 sells → 60% buy, threshold=60 → direction=buy."""
+        trades = _candle_trades(0, buy_count=6, sell_count=4)
+        r = compute_aggressor_imbalance_streak(trades, threshold_pct=60.0)
+        assert r["candles"][0]["direction"] == "buy"
+
+    def test_buy_pct_computed_correctly(self):
+        trades = _candle_trades(0, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["candles"][0]["buy_pct"] == pytest.approx(80.0)
+
+    def test_sell_pct_computed_correctly(self):
+        trades = _candle_trades(0, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["candles"][0]["sell_pct"] == pytest.approx(20.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Streak counting
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStreakCounting:
+    def test_single_imbalanced_candle_streak_one(self):
+        trades = _candle_trades(0, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 1
+        assert r["streak_direction"] == "buy"
+
+    def test_two_consecutive_buy_candles_streak_two(self):
+        trades = (
+            _candle_trades(0, buy_count=8, sell_count=2) +   # candle 0: buy
+            _candle_trades(60, buy_count=9, sell_count=1)    # candle 1: buy
+        )
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 2
+        assert r["streak_direction"] == "buy"
+
+    def test_three_consecutive_sell_candles_streak_three(self):
+        trades = (
+            _candle_trades(0,   buy_count=2, sell_count=8) +   # sell
+            _candle_trades(60,  buy_count=1, sell_count=9) +   # sell
+            _candle_trades(120, buy_count=2, sell_count=8)     # sell
+        )
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 3
+        assert r["streak_direction"] == "sell"
+
+    def test_streak_resets_on_balanced_candle(self):
+        """buy, balanced, buy → streak=1 (not 2)."""
+        trades = (
+            _candle_trades(0,   buy_count=8, sell_count=2) +   # buy
+            _candle_trades(60,  buy_count=5, sell_count=5) +   # balanced → resets
+            _candle_trades(120, buy_count=8, sell_count=2)     # buy → streak=1
+        )
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 1
+        assert r["streak_direction"] == "buy"
+
+    def test_streak_resets_on_direction_change(self):
+        """buy, sell → streak=1 sell (previous buy streak broken)."""
+        trades = (
+            _candle_trades(0,  buy_count=8, sell_count=2) +   # buy
+            _candle_trades(60, buy_count=2, sell_count=8)     # sell → new streak=1
+        )
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 1
+        assert r["streak_direction"] == "sell"
+
+    def test_streak_zero_when_last_candle_is_balanced(self):
+        """buy, buy, balanced → streak=0."""
+        trades = (
+            _candle_trades(0,   buy_count=8, sell_count=2) +
+            _candle_trades(60,  buy_count=8, sell_count=2) +
+            _candle_trades(120, buy_count=5, sell_count=5)    # balanced end
+        )
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 0
+        assert r["streak_direction"] is None
+
+    def test_longer_streak_counted_correctly(self):
+        trades = []
+        for i in range(6):
+            trades += _candle_trades(i * 60, buy_count=9, sell_count=1)
+        r = compute_aggressor_imbalance_streak(trades)
+        assert r["streak"] == 6
+        assert r["streak_direction"] == "buy"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Alert logic
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestAlertLogic:
+    def test_no_alert_below_threshold(self):
+        """2 consecutive buy candles → no alert (default alert_streak=3)."""
+        trades = (
+            _candle_trades(0,  buy_count=8, sell_count=2) +
+            _candle_trades(60, buy_count=8, sell_count=2)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert r["alert"] is False
+
+    def test_alert_fires_at_exactly_three(self):
+        trades = (
+            _candle_trades(0,   buy_count=8, sell_count=2) +
+            _candle_trades(60,  buy_count=8, sell_count=2) +
+            _candle_trades(120, buy_count=8, sell_count=2)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert r["alert"] is True
+        assert r["streak"] == 3
+
+    def test_alert_fires_for_sell_streak(self):
+        trades = (
+            _candle_trades(0,   buy_count=2, sell_count=8) +
+            _candle_trades(60,  buy_count=2, sell_count=8) +
+            _candle_trades(120, buy_count=2, sell_count=8)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert r["alert"] is True
+        assert r["streak_direction"] == "sell"
+
+    def test_alert_fires_above_threshold(self):
+        """4 consecutive buy candles, alert_streak=3 → should alert."""
+        trades = []
+        for i in range(4):
+            trades += _candle_trades(i * 60, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert r["alert"] is True
+        assert r["streak"] == 4
+
+    def test_custom_alert_streak(self):
+        """With alert_streak=2, 2 candles is enough to alert."""
+        trades = (
+            _candle_trades(0,  buy_count=8, sell_count=2) +
+            _candle_trades(60, buy_count=8, sell_count=2)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=2)
+        assert r["alert"] is True
+
+    def test_alert_false_when_streak_broken_before_threshold(self):
+        """buy, buy, balanced, buy → streak=1 → no alert."""
+        trades = (
+            _candle_trades(0,   buy_count=8, sell_count=2) +
+            _candle_trades(60,  buy_count=8, sell_count=2) +
+            _candle_trades(120, buy_count=5, sell_count=5) +
+            _candle_trades(180, buy_count=8, sell_count=2)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert r["alert"] is False
+        assert r["streak"] == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Description
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDescription:
+    def test_description_mentions_buy_on_buy_streak(self):
+        trades = (
+            _candle_trades(0,   buy_count=8, sell_count=2) +
+            _candle_trades(60,  buy_count=8, sell_count=2) +
+            _candle_trades(120, buy_count=8, sell_count=2)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert "buy" in r["description"].lower()
+
+    def test_description_mentions_sell_on_sell_streak(self):
+        trades = (
+            _candle_trades(0,   buy_count=2, sell_count=8) +
+            _candle_trades(60,  buy_count=2, sell_count=8) +
+            _candle_trades(120, buy_count=2, sell_count=8)
+        )
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert "sell" in r["description"].lower()
+
+    def test_description_mentions_streak_length(self):
+        trades = []
+        for i in range(4):
+            trades += _candle_trades(i * 60, buy_count=8, sell_count=2)
+        r = compute_aggressor_imbalance_streak(trades, alert_streak=3)
+        assert "4" in r["description"]
+
+    def test_description_non_empty_when_no_streak(self):
+        r = compute_aggressor_imbalance_streak([])
+        assert len(r["description"]) > 0


### PR DESCRIPTION
## Summary
- Tracks consecutive 1-min candles where buy **or** sell aggressor exceeds 70% threshold
- Alert fires at 3+ consecutive imbalanced candles (configurable via query param)
- Pure function `compute_aggressor_imbalance_streak(trades, bucket_size, threshold_pct, alert_streak)` in `metrics.py`
- `GET /aggressor-streak` endpoint (params: `symbol`, `window`, `bucket`, `threshold`, `alert_streak`)
- New dashboard card with streak count, direction badge, mini per-candle bar indicators

## Test plan
- [x] 37 TDD unit tests in `tests/test_aggressor_streak.py`
  - Structure: required fields, empty input, parameter reflection
  - Bucketing: 1-min windows, sorted order, floor alignment
  - Direction: buy/sell/balanced classification at boundary and custom thresholds
  - Streak: count, reset on balanced candle, reset on direction change, multi-candle
  - Alert: fires at exactly 3, fires above, no false positives, custom `alert_streak`
  - Description: mentions direction, streak length, non-empty on no data
- [x] black formatting applied
- [x] mypy: no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)