### PR TITLE
feat: liquidation heatmap endpoint + card

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -5132,53 +5132,74 @@ async def trade_size_percentiles(symbol: Optional[str] = None):
 
 @router.get("/liquidation-heatmap")
 async def liquidation_heatmap_endpoint(
-    symbol: Optional[str] = None,
+    window_s: int = Query(default=3600, ge=60, le=86400),
     buckets: int = Query(default=20, ge=5, le=100),
-    window: int = Query(default=86400, ge=3600, le=2592000),
 ):
-    """Liquidation heatmap: bucket liquidations by price level."""
-    from storage import DB_PATH
+    """
+    Return last `window_s` seconds of liquidations bucketed by price range,
+    for all tracked symbols. Each bucket carries long_usd, short_usd, total_usd.
+    """
+    now = time.time()
+    since = now - window_s
+    symbols = get_symbols()
+    result: dict = {}
 
-    syms = get_symbols()
-    target = symbol if symbol and symbol in syms else syms[0]
-    since = time.time() - window
+    for sym in symbols:
+        liqs = await get_recent_liquidations(limit=5000, since=since, symbol=sym)
+        if not liqs:
+            result[sym] = {
+                "buckets": [],
+                "price_min": None,
+                "price_max": None,
+                "total_usd": 0.0,
+                "n_liquidations": 0,
+            }
+            continue
 
-    async with aiosqlite.connect(DB_PATH) as db:
-        db.row_factory = aiosqlite.Row
-        async with db.execute(
-            "SELECT side, price, qty, value FROM liquidations WHERE symbol=? AND ts>=? ORDER BY ts DESC",
-            (target, since),
-        ) as cur:
-            rows = await cur.fetchall()
+        prices = [float(l["price"]) for l in liqs]
+        price_min = min(prices)
+        price_max = max(prices)
 
-    if not rows:
-        return {"status": "ok", "symbol": target, "buckets": [], "total_liqs": 0}
+        # Widen by 0.5% on each side so boundary liquidations fall inside a bucket
+        margin = (price_max - price_min) * 0.005 or price_min * 0.005 or 1e-9
+        price_min -= margin
+        price_max += margin
 
-    prices = [float(r["price"]) for r in rows]
-    price_min, price_max = min(prices), max(prices)
+        step = (price_max - price_min) / buckets
+        bkt_list = [
+            {
+                "price_low":  round(price_min + i * step, 10),
+                "price_high": round(price_min + (i + 1) * step, 10),
+                "long_usd":   0.0,
+                "short_usd":  0.0,
+                "total_usd":  0.0,
+            }
+            for i in range(buckets)
+        ]
 
-    # Avoid division by zero when all liqs are at same price
-    if price_max == price_min:
-        price_max = price_min + 1.0
+        for liq in liqs:
+            p = float(liq["price"])
+            frac = (p - price_min) / (price_max - price_min)
+            idx = max(0, min(buckets - 1, int(frac * buckets)))
+            usd = float(liq.get("value") or p * float(liq["qty"]))
+            if liq["side"] == "long":
+                bkt_list[idx]["long_usd"] += usd
+            else:
+                bkt_list[idx]["short_usd"] += usd
+            bkt_list[idx]["total_usd"] += usd
 
-    bucket_size = (price_max - price_min) / buckets
-    bucket_map: dict = {}  # (bucket_idx, side) -> {count, total_usd}
+        # Round for clean JSON
+        for b in bkt_list:
+            b["long_usd"]  = round(b["long_usd"],  2)
+            b["short_usd"] = round(b["short_usd"], 2)
+            b["total_usd"] = round(b["total_usd"], 2)
 
-    for r in rows:
-        price = float(r["price"])
-        side = r["side"]
-        value = float(r["value"] or 0) or float(r["price"]) * float(r["qty"])
-        idx = min(int((price - price_min) / bucket_size), buckets - 1)
-        key = (idx, side)
-        if key not in bucket_map:
-            bucket_map[key] = {"price": price_min + (idx + 0.5) * bucket_size, "count": 0, "total_usd": 0.0, "side": side}
-        bucket_map[key]["count"] += 1
-        bucket_map[key]["total_usd"] = round(bucket_map[key]["total_usd"] + value, 2)
+        result[sym] = {
+            "buckets":        bkt_list,
+            "price_min":      round(price_min, 10),
+            "price_max":      round(price_max, 10),
+            "total_usd":      round(sum(float(l.get("value") or 0) for l in liqs), 2),
+            "n_liquidations": len(liqs),
+        }
 
-    result_buckets = sorted(bucket_map.values(), key=lambda b: b["price"])
-    return {
-        "status": "ok",
-        "symbol": target,
-        "buckets": result_buckets,
-        "total_liqs": len(rows),
-    }
+    return JSONResponse({"status": "ok", "ts": now, "window_s": window_s, "symbols": result})

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1913,6 +1913,101 @@ async function renderObWalls() {
     </table>`;
 }
 
+// ── Liquidation Heatmap ───────────────────────────────────────────────────────
+async function renderLiqHeatmap() {
+  const data = await apiFetch('/liquidation-heatmap?window_s=3600&buckets=20');
+  const el    = document.getElementById('liq-heatmap-content');
+  const badge = document.getElementById('liq-heatmap-badge');
+  if (!el) return;
+
+  if (!data) { setErr('liq-heatmap-content'); return; }
+
+  const syms = Object.keys(data.symbols || {});
+  if (syms.length === 0) {
+    el.innerHTML = '<div style="color:var(--muted);font-size:11px;padding:8px 0">No liquidation data</div>';
+    return;
+  }
+
+  // Compute cross-symbol max for consistent colour scale
+  let globalMax = 0;
+  for (const s of syms) {
+    const entry = data.symbols[s];
+    for (const b of (entry.buckets || [])) globalMax = Math.max(globalMax, b.total_usd);
+  }
+
+  function liqColor(totalUsd, longUsd, shortUsd) {
+    if (totalUsd <= 0 || globalMax <= 0) return 'var(--bg3)';
+    const intensity = Math.log1p(totalUsd) / Math.log1p(globalMax);
+    const alpha = Math.max(0.08, intensity);
+    // long liquidations = price was dropping (forced longs out) → red
+    // short liquidations = price was rising (forced shorts out) → green
+    if (longUsd >= shortUsd) return `rgba(255,77,79,${alpha.toFixed(2)})`;
+    return `rgba(0,224,130,${alpha.toFixed(2)})`;
+  }
+
+  function fmtUsd(v) {
+    if (v >= 1e6) return '$' + (v / 1e6).toFixed(1) + 'M';
+    if (v >= 1e3) return '$' + (v / 1e3).toFixed(1) + 'k';
+    return '$' + v.toFixed(0);
+  }
+
+  // Badge: total liquidated across all symbols
+  const grandTotal = syms.reduce((s, k) => s + (data.symbols[k].total_usd || 0), 0);
+  if (badge) {
+    badge.textContent = fmtUsd(grandTotal);
+    badge.className = 'card-badge ' + (grandTotal > 50000 ? 'badge-red' : grandTotal > 5000 ? 'badge-yellow' : 'badge-blue');
+    badge.style.display = 'inline-block';
+  }
+
+  let html = '';
+  for (const sym of syms) {
+    const entry = data.symbols[sym];
+    const buckets = entry.buckets || [];
+    const label = sym.replace('USDT', '');
+    const symTotal = entry.total_usd || 0;
+    const nLiqs = entry.n_liquidations || 0;
+
+    html += `<div style="margin-bottom:10px">`;
+    html += `<div style="display:flex;justify-content:space-between;font-size:10px;color:var(--muted);margin-bottom:3px">`;
+    html += `<span style="font-weight:600;color:var(--fg)">${label}</span>`;
+    html += `<span>${nLiqs} liqs · ${fmtUsd(symTotal)}</span></div>`;
+
+    if (buckets.length === 0) {
+      html += `<div style="font-size:10px;color:var(--muted);padding:4px 0">No liquidations in window</div>`;
+    } else {
+      html += `<div style="display:flex;flex-direction:column;gap:1px">`;
+      // Render bucket strip: reversed so high price is on the right
+      const reversed = [...buckets].reverse();
+      html += `<div style="display:flex;gap:1px;height:28px;align-items:stretch">`;
+      for (const b of reversed) {
+        const col = liqColor(b.total_usd, b.long_usd, b.short_usd);
+        const tip = b.total_usd > 0
+          ? `${fmtUsd(b.total_usd)} (L:${fmtUsd(b.long_usd)} S:${fmtUsd(b.short_usd)})`
+          : '';
+        html += `<div title="${tip}" style="flex:1;background:${col};border-radius:1px;min-width:2px"></div>`;
+      }
+      html += `</div>`;
+      // Price axis: low price left, high price right
+      if (entry.price_min != null) {
+        const dec = entry.price_min < 0.01 ? 6 : entry.price_min < 1 ? 4 : 2;
+        html += `<div style="display:flex;justify-content:space-between;font-size:9px;color:var(--muted);margin-top:2px">`;
+        html += `<span>${entry.price_min.toFixed(dec)}</span><span>${entry.price_max.toFixed(dec)}</span></div>`;
+      }
+      html += `</div>`;
+    }
+    html += `</div>`;
+  }
+
+  // Legend
+  html += `<div style="display:flex;gap:12px;font-size:9px;color:var(--muted);margin-top:4px">`;
+  html += `<span><span style="color:var(--red)">■</span> longs liq'd</span>`;
+  html += `<span><span style="color:var(--green)">■</span> shorts liq'd</span>`;
+  html += `<span style="margin-left:auto">darker = larger</span>`;
+  html += `</div>`;
+
+  el.innerHTML = html;
+}
+
 // ── Top Movers ────────────────────────────────────────────────────────────────
 async function renderTopMovers() {
   const data = await apiFetch('/top-movers');
@@ -2019,6 +2114,7 @@ async function refresh() {
     safe(renderAggressorStreak),
     safe(renderObWalls),
     safe(renderTopMovers),
+    safe(renderLiqHeatmap),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -349,6 +349,18 @@
     </div>
   </section>
 
+  <!-- Liquidation Heatmap -->
+  <section class="card" id="card-liq-heatmap">
+    <div class="card-header">
+      <span class="card-title">Liquidation Heatmap</span>
+      <span id="liq-heatmap-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">price zones · 1h · long vs short</span>
+    </div>
+    <div id="liq-heatmap-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <section class="card" id="card-top-movers">
     <div class="card-header">
       <span class="card-title">Top Movers</span>


### PR DESCRIPTION
Adds /api/liquidation-heatmap endpoint returning liquidations bucketed by price range and symbol over 1h window. Frontend heatmap card shows intensity by color.