### PR TITLE
feat: net taker delta per symbol card

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2092,6 +2092,76 @@ async function renderLiqHeatmap() {
   el.innerHTML = html;
 }
 
+// ── Net Taker Delta ───────────────────────────────────────────────────────────
+async function renderNetTakerDelta() {
+  const el    = document.getElementById('net-taker-delta-content');
+  const badge = document.getElementById('net-taker-delta-badge');
+  if (!el) return;
+
+  // Fetch for all symbols in parallel
+  const symbols = getSymbols();
+  const results = await Promise.all(
+    symbols.map(sym =>
+      apiFetch(`/net-taker-delta?symbol=${encodeURIComponent(sym)}&window=3600`)
+        .then(d => d ? { symbol: sym, total_net: d.total_net, total_buy: d.total_buy, total_sell: d.total_sell } : null)
+        .catch(() => null)
+    )
+  );
+
+  const rows = results.filter(Boolean);
+  if (!rows.length) { setErr('net-taker-delta-content'); return; }
+
+  // Sort by total_net descending for ranking
+  rows.sort((a, b) => b.total_net - a.total_net);
+  rows.forEach((r, i) => { r.rank = i + 1; });
+
+  // Badge reflects top symbol's direction
+  const top = rows[0];
+  if (badge) {
+    let label = 'neutral', cls = 'badge-blue';
+    if (top.total_net > 0)      { label = 'buying';  cls = 'badge-green'; }
+    else if (top.total_net < 0) { label = 'selling'; cls = 'badge-red'; }
+    badge.textContent = label;
+    badge.className   = `card-badge ${cls}`;
+    badge.style.display = '';
+  }
+
+  function fmtVol(v) {
+    const abs = Math.abs(v);
+    if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M`;
+    if (abs >= 1_000)     return `${(v / 1_000).toFixed(1)}k`;
+    return v.toFixed(2);
+  }
+
+  const rowsHtml = rows.map(r => {
+    const total = r.total_buy + r.total_sell;
+    const buyPct = total > 0 ? Math.round(r.total_buy / total * 100) : 50;
+    const netPos = r.total_net >= 0;
+    const netColor = netPos ? 'var(--green)' : 'var(--red)';
+    const netSign  = netPos ? '+' : '';
+    return `<tr>
+      <td style="color:var(--muted);font-size:10px;">#${r.rank}</td>
+      <td style="font-size:11px;">${r.symbol.replace('USDT','')}</td>
+      <td style="font-size:11px;color:${netColor};text-align:right;">${netSign}${fmtVol(r.total_net)}</td>
+      <td style="width:60px;padding-left:6px;">
+        <div style="background:var(--red);height:6px;border-radius:3px;position:relative;">
+          <div style="background:var(--green);width:${buyPct}%;height:100%;border-radius:3px 0 0 3px;"></div>
+        </div>
+      </td>
+    </tr>`;
+  }).join('');
+
+  el.innerHTML = `<table style="width:100%;border-collapse:collapse;font-size:11px;">
+    <thead><tr>
+      <th style="color:var(--muted);text-align:left;font-size:10px;padding-bottom:4px;">#</th>
+      <th style="color:var(--muted);text-align:left;font-size:10px;">Symbol</th>
+      <th style="color:var(--muted);text-align:right;font-size:10px;">Net Δ</th>
+      <th style="color:var(--muted);font-size:10px;padding-left:6px;">Buy/Sell</th>
+    </tr></thead>
+    <tbody>${rowsHtml}</tbody>
+  </table>`;
+}
+
 // ── Top Movers ────────────────────────────────────────────────────────────────
 async function renderTopMovers() {
   const data = await apiFetch('/top-movers');
@@ -2200,6 +2270,7 @@ async function refresh() {
     safe(renderObWalls),
     safe(renderTopMovers),
     safe(renderLiqHeatmap),
+    safe(renderNetTakerDelta),
   ]);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -384,6 +384,18 @@
     </div>
   </section>
 
+  <!-- Net Taker Delta -->
+  <section class="card" id="card-net-taker-delta">
+    <div class="card-header">
+      <span class="card-title">Net Taker Delta</span>
+      <span id="net-taker-delta-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">buy − sell vol · 1h · all symbols</span>
+    </div>
+    <div id="net-taker-delta-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
 </main>
 
 <script src="app.js?v=7"></script>

--- a/tests/test_net_taker_delta.py
+++ b/tests/test_net_taker_delta.py
@@ -1,0 +1,291 @@
+"""
+Unit / smoke tests for /api/net-taker-delta + net taker delta card.
+
+Validates:
+  - Response shape
+  - Python mirrors of display-helper logic
+  - Ranking logic (multi-symbol comparison)
+  - Color coding helpers
+  - HTML card / JS smoke tests
+  - Route registration
+"""
+import os
+import sys
+
+import pytest
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _html() -> str:
+    with open(os.path.join(_ROOT, "frontend", "index.html"), encoding="utf-8") as f:
+        return f.read()
+
+
+def _js() -> str:
+    with open(os.path.join(_ROOT, "frontend", "app.js"), encoding="utf-8") as f:
+        return f.read()
+
+
+# ── Python mirrors of display helpers ────────────────────────────────────────
+
+def fmt_vol(v: float) -> str:
+    """Format volume (coin units) with K/M suffix."""
+    if abs(v) >= 1_000_000:
+        return f"{v / 1_000_000:.2f}M"
+    if abs(v) >= 1_000:
+        return f"{v / 1_000:.1f}k"
+    return f"{v:.2f}"
+
+
+def net_delta_badge(total_net: float) -> tuple[str, str]:
+    """Returns (label, css_class) for the net delta direction badge."""
+    if total_net > 0:
+        return "buying", "badge-green"
+    if total_net < 0:
+        return "selling", "badge-red"
+    return "neutral", "badge-blue"
+
+
+def delta_pressure_pct(total_buy: float, total_sell: float) -> int:
+    """Buy pressure as percentage of total volume (0–100)."""
+    total = total_buy + total_sell
+    if total <= 0:
+        return 50
+    return max(0, min(100, round(total_buy / total * 100)))
+
+
+def rank_symbols(symbol_data: list[dict]) -> list[dict]:
+    """
+    Sort symbols by total_net descending, add rank field.
+    symbol_data: [{"symbol": str, "total_net": float, "total_buy": float, "total_sell": float}]
+    """
+    sorted_data = sorted(symbol_data, key=lambda x: x["total_net"], reverse=True)
+    for i, row in enumerate(sorted_data, start=1):
+        row["rank"] = i
+    return sorted_data
+
+
+# ── Sample payloads ───────────────────────────────────────────────────────────
+
+NET_TAKER_PAYLOAD = {
+    "status": "ok",
+    "symbol": "BANANAS31USDT",
+    "window_seconds": 3600,
+    "bucket_seconds": 60,
+    "buckets": [
+        {"ts": 1700000060.0, "buy_vol": 1200.0, "sell_vol": 800.0, "net_delta": 400.0},
+        {"ts": 1700000120.0, "buy_vol": 900.0,  "sell_vol": 1100.0, "net_delta": -200.0},
+    ],
+    "total_buy": 2100.0,
+    "total_sell": 1900.0,
+    "total_net": 200.0,
+}
+
+NET_TAKER_BEARISH = {
+    "status": "ok",
+    "symbol": "COSUSDT",
+    "window_seconds": 3600,
+    "bucket_seconds": 60,
+    "buckets": [
+        {"ts": 1700000060.0, "buy_vol": 300.0, "sell_vol": 700.0, "net_delta": -400.0},
+    ],
+    "total_buy": 300.0,
+    "total_sell": 700.0,
+    "total_net": -400.0,
+}
+
+NET_TAKER_NEUTRAL = {
+    "status": "ok",
+    "symbol": "DEXEUSDT",
+    "window_seconds": 3600,
+    "bucket_seconds": 60,
+    "buckets": [],
+    "total_buy": 0.0,
+    "total_sell": 0.0,
+    "total_net": 0.0,
+}
+
+
+# ── Response shape tests ──────────────────────────────────────────────────────
+
+def test_net_taker_response_has_status():
+    assert NET_TAKER_PAYLOAD["status"] == "ok"
+
+
+def test_net_taker_has_required_keys():
+    for key in ("symbol", "window_seconds", "bucket_seconds", "buckets",
+                "total_buy", "total_sell", "total_net"):
+        assert key in NET_TAKER_PAYLOAD
+
+
+def test_net_taker_buckets_is_list():
+    assert isinstance(NET_TAKER_PAYLOAD["buckets"], list)
+
+
+def test_net_taker_each_bucket_has_required_keys():
+    for bucket in NET_TAKER_PAYLOAD["buckets"]:
+        for key in ("ts", "buy_vol", "sell_vol", "net_delta"):
+            assert key in bucket
+
+
+def test_net_taker_net_equals_buy_minus_sell():
+    p = NET_TAKER_PAYLOAD
+    assert p["total_net"] == pytest.approx(p["total_buy"] - p["total_sell"])
+
+
+def test_net_taker_bucket_net_delta_correct():
+    b = NET_TAKER_PAYLOAD["buckets"][0]
+    assert b["net_delta"] == pytest.approx(b["buy_vol"] - b["sell_vol"])
+
+
+# ── fmt_vol tests ─────────────────────────────────────────────────────────────
+
+def test_fmt_vol_millions():
+    assert fmt_vol(2_500_000.0) == "2.50M"
+
+
+def test_fmt_vol_thousands():
+    assert fmt_vol(1_500.0) == "1.5k"
+
+
+def test_fmt_vol_small():
+    assert fmt_vol(999.0) == "999.00"
+
+
+def test_fmt_vol_negative_thousands():
+    assert fmt_vol(-1_200.0) == "-1.2k"
+
+
+def test_fmt_vol_zero():
+    assert fmt_vol(0.0) == "0.00"
+
+
+# ── net_delta_badge tests ─────────────────────────────────────────────────────
+
+def test_badge_positive_net():
+    label, cls = net_delta_badge(200.0)
+    assert label == "buying"
+    assert cls == "badge-green"
+
+
+def test_badge_negative_net():
+    label, cls = net_delta_badge(-400.0)
+    assert label == "selling"
+    assert cls == "badge-red"
+
+
+def test_badge_zero_net():
+    label, cls = net_delta_badge(0.0)
+    assert label == "neutral"
+    assert cls == "badge-blue"
+
+
+# ── delta_pressure_pct tests ──────────────────────────────────────────────────
+
+def test_pressure_pct_equal():
+    assert delta_pressure_pct(500.0, 500.0) == 50
+
+
+def test_pressure_pct_all_buy():
+    assert delta_pressure_pct(1000.0, 0.0) == 100
+
+
+def test_pressure_pct_all_sell():
+    assert delta_pressure_pct(0.0, 1000.0) == 0
+
+
+def test_pressure_pct_zero_total():
+    assert delta_pressure_pct(0.0, 0.0) == 50
+
+
+def test_pressure_pct_clamped():
+    assert delta_pressure_pct(200.0, 100.0) == 67
+
+
+def test_pressure_pct_bullish_payload():
+    p = NET_TAKER_PAYLOAD
+    pct = delta_pressure_pct(p["total_buy"], p["total_sell"])
+    assert pct > 50  # more buying than selling
+
+
+def test_pressure_pct_bearish_payload():
+    p = NET_TAKER_BEARISH
+    pct = delta_pressure_pct(p["total_buy"], p["total_sell"])
+    assert pct < 50  # more selling than buying
+
+
+# ── rank_symbols tests ────────────────────────────────────────────────────────
+
+FOUR_SYMBOLS_DELTA = [
+    {"symbol": "BANANAS31USDT", "total_net": 200.0,   "total_buy": 2100.0, "total_sell": 1900.0},
+    {"symbol": "COSUSDT",       "total_net": -400.0,  "total_buy": 300.0,  "total_sell": 700.0},
+    {"symbol": "DEXEUSDT",      "total_net": 0.0,     "total_buy": 0.0,    "total_sell": 0.0},
+    {"symbol": "LYNUSDT",       "total_net": 1500.0,  "total_buy": 3000.0, "total_sell": 1500.0},
+]
+
+
+def test_rank_1_is_highest_net():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    assert ranked[0]["symbol"] == "LYNUSDT"
+    assert ranked[0]["rank"] == 1
+
+
+def test_rank_last_is_most_negative():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    assert ranked[-1]["symbol"] == "COSUSDT"
+    assert ranked[-1]["rank"] == 4
+
+
+def test_ranks_are_sequential():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    assert [r["rank"] for r in ranked] == [1, 2, 3, 4]
+
+
+def test_ranked_in_descending_net_order():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    nets = [r["total_net"] for r in ranked]
+    assert nets == sorted(nets, reverse=True)
+
+
+def test_all_symbols_present_after_ranking():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    syms = {r["symbol"] for r in ranked}
+    assert syms == {"BANANAS31USDT", "COSUSDT", "DEXEUSDT", "LYNUSDT"}
+
+
+def test_no_duplicate_ranks():
+    ranked = rank_symbols([d.copy() for d in FOUR_SYMBOLS_DELTA])
+    ranks = [r["rank"] for r in ranked]
+    assert len(ranks) == len(set(ranks))
+
+
+def test_single_symbol_rank_is_one():
+    ranked = rank_symbols([{"symbol": "X", "total_net": 100.0, "total_buy": 200.0, "total_sell": 100.0}])
+    assert ranked[0]["rank"] == 1
+
+
+# ── Route registration ────────────────────────────────────────────────────────
+
+def test_net_taker_delta_route_registered():
+    import tempfile
+    os.environ.setdefault("DB_PATH", os.path.join(tempfile.mkdtemp(), "t.db"))
+    os.environ.setdefault("SYMBOL_BINANCE", "BANANAS31USDT")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+    from api import router
+    paths = [r.path for r in router.routes]
+    assert any("net-taker-delta" in p for p in paths)
+
+
+# ── HTML / JS smoke tests ─────────────────────────────────────────────────────
+
+def test_html_has_net_taker_delta_card():
+    assert "card-net-taker-delta" in _html()
+
+
+def test_js_has_render_net_taker_delta():
+    assert "renderNetTakerDelta" in _js()
+
+
+def test_js_calls_net_taker_delta_api():
+    assert "net-taker-delta" in _js()


### PR DESCRIPTION
## Summary
- Add net taker delta card showing buy-initiated minus sell-initiated volume over 1h rolling window per symbol, ranked list with directional color coding
- Fetches `/api/net-taker-delta` for all 4 symbols in parallel
- Ranks symbols by `total_net` (buy vol − sell vol) descending
- Direction badge on leading symbol (buying=green, selling=red, neutral=blue)
- Per-row buy/sell pressure split bar for visual directional pressure

## Test plan
- [x] 32 tests in `tests/test_net_taker_delta.py` — response shape, `fmt_vol`, `net_delta_badge`, `delta_pressure_pct`, `rank_symbols`, route registration, HTML/JS smoke tests
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)