### PR TITLE
feat: DeFi TVL tracker with protocol rankings and chain dominance breakdown

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -72,6 +72,7 @@ from metrics import (
     compute_layer2_metrics,
     compute_derivatives_heatmap,
     compute_network_health_score,
+    compute_defi_tvl_tracker,
 )
 
 router = APIRouter(prefix="/api")
@@ -5303,6 +5304,10 @@ async def derivatives_heatmap_endpoint(
 ):
     """OI heatmap by strike and expiry with max pain and GEX for BTC/ETH options."""
     data = await compute_derivatives_heatmap(asset=asset)
+@router.get("/defi-tvl-tracker")
+async def defi_tvl_tracker_endpoint():
+    """DeFi TVL tracker: top 10 protocols, chain dominance, momentum, 30d sparkline."""
+    data = await compute_defi_tvl_tracker()
     return JSONResponse(data)
 @router.get("/network-health-score")
 async def network_health_score_endpoint():

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -6088,6 +6088,274 @@ async def compute_macro_liquidity_indicator() -> dict:
         },
         "history_90d": history_90d,
         "description": desc,
+        "description": desc,
+    }
+
+
+# ── DeFi TVL Tracker ───────────────────────────────────────────────────────────
+# Dashboard card: top 10 protocols by TVL, chain dominance breakdown,
+# TVL momentum signal, and 30-day sparkline history.
+# Data: DeFi Llama public API (free, no auth) with realistic mock fallback.
+
+_DT_PROTOCOLS_URL: str = "https://api.llama.fi/protocols"
+_DT_HISTORY_URL:   str = "https://api.llama.fi/v2/historicalChainTvl"
+_DT_CHAINS_URL:    str = "https://api.llama.fi/chains"
+_DT_TOP_N:         int = 10
+_DT_DOM_THRESHOLD: float = 3.0   # % below which a chain collapses into "Others"
+
+# Momentum thresholds: 7d TVL change
+_DT_ACCEL_THR: float =  5.0   # % gain
+_DT_DECL_THR:  float = -5.0   # % loss
+
+# Realistic mock data for when the API is unavailable
+_DT_MOCK_PROTOCOLS: list = [
+    {"name": "Lido",           "tvl": 28_100_000_000.0, "chain": "Ethereum",  "category": "Liquid Staking", "change1d": 0.012,  "change7d": 0.035},
+    {"name": "AAVE",           "tvl": 12_300_000_000.0, "chain": "Multi",     "category": "Lending",        "change1d": 0.005,  "change7d": -0.021},
+    {"name": "Uniswap",        "tvl":  6_540_000_000.0, "chain": "Ethereum",  "category": "DEX",            "change1d": 0.031,  "change7d":  0.010},
+    {"name": "Curve Finance",  "tvl":  5_820_000_000.0, "chain": "Multi",     "category": "DEX",            "change1d": -0.003, "change7d": -0.042},
+    {"name": "MakerDAO",       "tvl":  5_210_000_000.0, "chain": "Ethereum",  "category": "CDP",            "change1d": 0.008,  "change7d":  0.005},
+    {"name": "JustLend",       "tvl":  4_720_000_000.0, "chain": "Tron",      "category": "Lending",        "change1d": 0.015,  "change7d":  0.028},
+    {"name": "Kamino",         "tvl":  3_180_000_000.0, "chain": "Solana",    "category": "Lending",        "change1d": 0.042,  "change7d":  0.081},
+    {"name": "EigenLayer",     "tvl":  3_010_000_000.0, "chain": "Ethereum",  "category": "Restaking",      "change1d": 0.000,  "change7d": -0.012},
+    {"name": "PancakeSwap",    "tvl":  2_150_000_000.0, "chain": "BSC",       "category": "DEX",            "change1d": 0.019,  "change7d":  0.033},
+    {"name": "GMX",            "tvl":  1_820_000_000.0, "chain": "Arbitrum",  "category": "Derivatives",    "change1d": 0.027,  "change7d":  0.059},
+    {"name": "Compound",       "tvl":  1_650_000_000.0, "chain": "Ethereum",  "category": "Lending",        "change1d": -0.002, "change7d": -0.018},
+    {"name": "Raydium",        "tvl":  1_420_000_000.0, "chain": "Solana",    "category": "DEX",            "change1d": 0.038,  "change7d":  0.095},
+]
+_DT_MOCK_CHAINS: dict = {
+    "Ethereum": 54_910_000_000.0,
+    "Tron":      7_690_000_000.0,
+    "BSC":       7_695_000_000.0,
+    "Solana":    6_080_000_000.0,
+    "Arbitrum":  4_940_000_000.0,
+    "Base":      3_200_000_000.0,
+    "Optimism":  2_110_000_000.0,
+    "Avalanche": 1_340_000_000.0,
+    "Polygon":   1_200_000_000.0,
+    "Others":    5_835_000_000.0,
+}
+
+
+def _dt_tvl_change_pct(current: float, previous: float) -> float:
+    """Percentage change from previous to current TVL. Returns 0 when previous=0."""
+    if previous <= 0:
+        return 0.0
+    return float(round((current - previous) / previous * 100.0, 4))
+
+
+def _dt_chain_dominance(chain_tvls: dict) -> dict:
+    """Normalise chain TVL values to percentage shares. Returns {} when total=0."""
+    total = sum(chain_tvls.values())
+    if total <= 0:
+        return {}
+    return {
+        chain: float(round(tvl / total * 100.0, 4))
+        for chain, tvl in chain_tvls.items()
+    }
+
+
+def _dt_momentum_signal(tvl_series: list) -> str:
+    """
+    Classify TVL momentum from a time-ordered series.
+    Computes 7-day change % from the series endpoints.
+    accelerating: change > +5% | declining: change < -5% | stable: otherwise
+    """
+    if len(tvl_series) < 2:
+        return "stable"
+    start = tvl_series[0]
+    end   = tvl_series[-1]
+    if start <= 0:
+        return "stable"
+    change_pct = (end - start) / start * 100.0
+    if change_pct > _DT_ACCEL_THR:
+        return "accelerating"
+    if change_pct < _DT_DECL_THR:
+        return "declining"
+    return "stable"
+
+
+def _dt_rank_protocols(protocols: list, n: int) -> list:
+    """Return top n protocols sorted by tvl_usd descending."""
+    if not protocols:
+        return []
+    ranked = sorted(protocols, key=lambda p: float(p.get("tvl_usd", 0)), reverse=True)
+    return ranked[:n]
+
+
+def _dt_format_tvl(usd: float) -> str:
+    """Format USD value as human-readable string: $1.5B, $250M, $500K."""
+    if usd >= 1_000_000_000:
+        return f"${usd / 1_000_000_000:.2f}B"
+    if usd >= 1_000_000:
+        return f"${usd / 1_000_000:.1f}M"
+    if usd >= 1_000:
+        return f"${usd / 1_000:.1f}K"
+    return f"${usd:.0f}"
+
+
+def _dt_category_breakdown(protocols: list) -> dict:
+    """Sum TVL by category across all protocols. Skips entries without 'category'."""
+    breakdown: dict = {}
+    for p in protocols:
+        cat = p.get("category")
+        if not cat:
+            continue
+        tvl = float(p.get("tvl_usd", 0))
+        breakdown[cat] = breakdown.get(cat, 0.0) + tvl
+    return breakdown
+
+
+def _dt_dominance_others(chain_pcts: dict, threshold: float = _DT_DOM_THRESHOLD) -> dict:
+    """
+    Collapse chains below threshold % into an "Others" bucket.
+    Returns {} for empty input. No "Others" key if nothing collapses.
+    """
+    if not chain_pcts:
+        return {}
+    result: dict = {}
+    others: float = 0.0
+    for chain, pct in chain_pcts.items():
+        if chain == "Others":
+            others += pct
+        elif pct >= threshold:
+            result[chain] = pct
+        else:
+            others += pct
+    if others > 0:
+        result["Others"] = round(others, 4)
+    return result
+
+
+async def compute_defi_tvl_tracker() -> dict:
+    """
+    DeFi TVL tracker: top protocols, chain dominance, momentum, sparkline.
+    Fetches from DeFi Llama; falls back to realistic mock data on error.
+    """
+    import aiohttp  # noqa: PLC0415
+    import asyncio as _asyncio  # noqa: PLC0415
+
+    raw_protocols: list = []
+    raw_chains:    list = []
+    raw_history:   list = []
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=12)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async def _get(url: str):
+                try:
+                    async with session.get(url) as r:
+                        return await r.json(content_type=None)
+                except Exception:
+                    return None
+
+            proto_data, chains_data, hist_data = await _asyncio.gather(
+                _get(_DT_PROTOCOLS_URL),
+                _get(_DT_CHAINS_URL),
+                _get(_DT_HISTORY_URL),
+            )
+
+        if isinstance(proto_data, list):
+            raw_protocols = proto_data
+        if isinstance(chains_data, list):
+            raw_chains = chains_data
+        if isinstance(hist_data, list):
+            raw_history = hist_data
+
+    except Exception:
+        pass
+
+    # ── Build protocol list ──────────────────────────────────────────────────
+    if raw_protocols:
+        protocols_norm = []
+        for p in raw_protocols:
+            tvl = float(p.get("tvl", 0) or 0)
+            if tvl <= 0:
+                continue
+            c1d = float(p.get("change_1d", 0) or 0)
+            c7d = float(p.get("change_7d", 0) or 0)
+            protocols_norm.append({
+                "name":           p.get("name", "Unknown"),
+                "tvl_usd":        tvl,
+                "chain":          p.get("chain", "Multi") or "Multi",
+                "category":       p.get("category", "Other") or "Other",
+                "change_24h_pct": round(c1d * 100, 2),
+                "change_7d_pct":  round(c7d * 100, 2),
+            })
+    else:
+        # Mock fallback
+        protocols_norm = [
+            {
+                "name":           p["name"],
+                "tvl_usd":        p["tvl"],
+                "chain":          p["chain"],
+                "category":       p["category"],
+                "change_24h_pct": round(p["change1d"] * 100, 2),
+                "change_7d_pct":  round(p["change7d"] * 100, 2),
+            }
+            for p in _DT_MOCK_PROTOCOLS
+        ]
+
+    top_protocols = _dt_rank_protocols(protocols_norm, _DT_TOP_N)
+    total_tvl = sum(p["tvl_usd"] for p in protocols_norm)
+
+    # ── Chain dominance ──────────────────────────────────────────────────────
+    if raw_chains:
+        chain_tvl_map: dict = {}
+        for c in raw_chains:
+            name = c.get("name", "Unknown")
+            tvl  = float(c.get("tvl", 0) or 0)
+            if tvl > 0:
+                chain_tvl_map[name] = tvl
+        chain_pcts = _dt_chain_dominance(chain_tvl_map)
+    else:
+        chain_pcts = _dt_chain_dominance(_DT_MOCK_CHAINS)
+
+    chain_dom = _dt_dominance_others(chain_pcts, _DT_DOM_THRESHOLD)
+
+    # ── Historical TVL ───────────────────────────────────────────────────────
+    if raw_history:
+        hist_vals = [float(h.get("tvl", 0)) for h in raw_history[-30:] if h.get("tvl")]
+        hist_out  = [
+            {"date": h.get("date", f"day-{i+1}"), "tvl_usd": float(h.get("tvl", 0))}
+            for i, h in enumerate(raw_history[-30:])
+        ]
+    else:
+        # Mock: 30 days of realistic data around current total
+        import random as _random  # noqa: PLC0415
+        _random.seed(42)
+        base = 90_000_000_000.0
+        hist_vals = []
+        for i in range(30):
+            base *= 1 + _random.uniform(-0.02, 0.025)
+            hist_vals.append(round(base, 0))
+        hist_out = [
+            {"date": f"day-{i+1}", "tvl_usd": v}
+            for i, v in enumerate(hist_vals)
+        ]
+
+    # ── Momentum & changes ───────────────────────────────────────────────────
+    momentum = _dt_momentum_signal(hist_vals)
+    tvl_24h_ago = hist_vals[-2] if len(hist_vals) >= 2 else total_tvl
+    tvl_7d_ago  = hist_vals[-8] if len(hist_vals) >= 8 else total_tvl
+    change_24h  = _dt_tvl_change_pct(total_tvl, tvl_24h_ago)
+    change_7d   = _dt_tvl_change_pct(total_tvl, tvl_7d_ago)
+
+    # ── Description ──────────────────────────────────────────────────────────
+    eth_dom = chain_dom.get("Ethereum", 0)
+    desc = (
+        f"DeFi TVL {_dt_format_tvl(total_tvl)} — "
+        f"{momentum} momentum, ETH dominance {eth_dom:.0f}%"
+    )
+
+    return {
+        "total_tvl_usd":      round(total_tvl, 2),
+        "tvl_change_24h_pct": round(change_24h, 2),
+        "tvl_change_7d_pct":  round(change_7d, 2),
+        "momentum":            momentum,
+        "protocols":           top_protocols,
+        "chain_dominance":     chain_dom,
+        "history":             hist_out,
+        "description":         desc,
     }
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2839,6 +2839,8 @@ async function refresh() {
     await Promise.all([safe(renderDerivativesHeatmap)]);
     // Batch 16: network health score
     await Promise.all([safe(renderNetworkHealthScore)]);
+    // Batch 24: DeFi TVL tracker
+    await Promise.all([safe(renderDefiTvlTracker)]);
   } finally {
     _refreshRunning = false;
   }
@@ -3473,6 +3475,103 @@ async function renderLayer2Metrics() {
     </div>
     ${sparkSvg}
     ${data.description ? `<div style="font-size:10px;color:var(--muted)">${data.description}</div>` : ''}`;
+}
+
+// ── DeFi TVL Tracker ─────────────────────────────────────────────────────────
+async function renderDefiTvlTracker() {
+  const el    = document.getElementById('defi-tvl-tracker-content');
+  const badge = document.getElementById('defi-tvl-tracker-badge');
+  if (!el) return;
+  const data = await apiFetch('/defi-tvl-tracker');
+  if (!data) { setErr('defi-tvl-tracker-content'); return; }
+
+  const totalTvl  = data.total_tvl_usd      ?? 0;
+  const chg24h    = data.tvl_change_24h_pct  ?? 0;
+  const chg7d     = data.tvl_change_7d_pct   ?? 0;
+  const momentum  = data.momentum            || 'stable';
+  const protocols = data.protocols           || [];
+  const chainDom  = data.chain_dominance     || {};
+  const history   = data.history             || [];
+
+  const momCls = momentum === 'accelerating' ? 'badge-green'
+               : momentum === 'declining'    ? 'badge-red'
+               : 'badge-blue';
+  if (badge) {
+    badge.textContent = momentum.toUpperCase();
+    badge.className   = `card-badge ${momCls}`;
+    badge.style.display = '';
+  }
+
+  const fmtB = v => {
+    const a = Math.abs(v);
+    if (a >= 1e9) return '$' + (a / 1e9).toFixed(1) + 'B';
+    if (a >= 1e6) return '$' + (a / 1e6).toFixed(0) + 'M';
+    return '$' + a.toFixed(0);
+  };
+  const fmtPct = v => (v >= 0 ? '+' : '') + v.toFixed(2) + '%';
+  const pctCol = v => v >= 0 ? 'var(--green)' : 'var(--red)';
+
+  // Top protocols table (top 5 to fit the card)
+  const protoRows = protocols.slice(0, 5).map((p, i) => {
+    const tvl  = fmtB(p.tvl_usd || 0);
+    const c24  = fmtPct(p.change_24h_pct || 0);
+    const c7d  = fmtPct(p.change_7d_pct  || 0);
+    return `<tr>
+      <td style="font-size:9px;color:var(--muted);padding:1px 3px">${i + 1}</td>
+      <td style="font-size:9px;color:var(--fg);padding:1px 3px;white-space:nowrap">${p.name || '—'}</td>
+      <td style="font-size:9px;color:var(--fg);text-align:right;padding:1px 3px">${tvl}</td>
+      <td style="font-size:9px;color:${pctCol(p.change_24h_pct||0)};text-align:right;padding:1px 3px">${c24}</td>
+      <td style="font-size:9px;color:${pctCol(p.change_7d_pct||0)};text-align:right;padding:1px 3px">${c7d}</td>
+    </tr>`;
+  }).join('');
+
+  // Chain dominance bar
+  const chainOrder = Object.entries(chainDom)
+    .filter(([k]) => k !== 'Others')
+    .sort((a, b) => b[1] - a[1])
+    .concat(Object.entries(chainDom).filter(([k]) => k === 'Others'));
+  const chainColors = ['var(--blue)', 'var(--green)', 'var(--yellow,#f0a500)', 'var(--red)', 'var(--muted)', 'var(--border)'];
+  const domBar = chainOrder.map(([chain, pct], i) => {
+    const col = chainColors[i % chainColors.length];
+    const w   = pct.toFixed(1);
+    return `<div title="${chain}: ${w}%" style="display:inline-block;width:${w}%;height:8px;background:${col};vertical-align:top"></div>`;
+  }).join('');
+  const domLegend = chainOrder.slice(0, 4).map(([chain, pct], i) => {
+    const col = chainColors[i % chainColors.length];
+    return `<span style="font-size:8px;color:${col};margin-right:6px">■ ${chain} ${pct.toFixed(0)}%</span>`;
+  }).join('');
+
+  // Sparkline
+  const sparkVals = history.map(h => h.tvl_usd || 0);
+  const sparkMin  = Math.min(...sparkVals) * 0.98;
+  const sparkMax  = Math.max(...sparkVals) * 1.02;
+  const sparkRange = sparkMax - sparkMin || 1;
+  const sparkbars = sparkVals.slice(-14).map(v => {
+    const h   = Math.max(2, Math.round((v - sparkMin) / sparkRange * 18));
+    const col = v >= sparkVals[sparkVals.length - 1] * 0.98 ? 'var(--green)' : 'var(--muted)';
+    return `<span style="display:inline-block;width:5px;height:${h}px;background:${col};margin-right:1px;vertical-align:bottom;opacity:0.75"></span>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>TVL: <b style="color:var(--fg)">${fmtB(totalTvl)}</b></span>
+      <span>24h: <b style="color:${pctCol(chg24h)}">${fmtPct(chg24h)}</b></span>
+      <span>7d: <b style="color:${pctCol(chg7d)}">${fmtPct(chg7d)}</b></span>
+    </div>
+    <div style="margin-bottom:3px;width:100%;border-radius:3px;overflow:hidden">${domBar}</div>
+    <div style="margin-bottom:6px">${domLegend}</div>
+    <table style="border-collapse:collapse;width:100%;margin-bottom:4px">
+      <thead><tr>
+        <th style="font-size:8px;color:var(--muted);text-align:left;padding:1px 3px">#</th>
+        <th style="font-size:8px;color:var(--muted);text-align:left;padding:1px 3px">Protocol</th>
+        <th style="font-size:8px;color:var(--muted);text-align:right;padding:1px 3px">TVL</th>
+        <th style="font-size:8px;color:var(--muted);text-align:right;padding:1px 3px">24h</th>
+        <th style="font-size:8px;color:var(--muted);text-align:right;padding:1px 3px">7d</th>
+      </tr></thead>
+      <tbody>${protoRows}</tbody>
+    </table>
+    <div style="margin-top:4px;line-height:18px">${sparkbars}</div>
+    ${data.description ? `<div style="font-size:10px;color:var(--muted);margin-top:4px">${data.description}</div>` : ''}`;
 }
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -643,6 +643,13 @@
       <span class="card-meta">ARB/OP/Base/Polygon/zkSync · TVL · bridge · gas</span>
     </div>
     <div id="layer2-metrics-content">
+  <section class="card" id="card-defi-tvl-tracker">
+    <div class="card-header">
+      <span class="card-title">DeFi TVL</span>
+      <span id="defi-tvl-tracker-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">top protocols · chain dominance · momentum · 30d sparkline</span>
+    </div>
+    <div id="defi-tvl-tracker-content">
       <div class="text-muted" style="font-size:11px;">Loading…</div>
     </div>
   </section>

--- a/tests/test_defi_tvl_tracker.py
+++ b/tests/test_defi_tvl_tracker.py
@@ -1,0 +1,400 @@
+"""
+Unit / smoke tests for /api/defi-tvl-tracker.
+
+DeFi TVL tracker — top protocols by TVL, chain dominance breakdown,
+momentum signal, and 30-day sparkline history.
+
+Data source: DeFi Llama public API (free, no auth required).
+Mock data layer provides realistic fallback values.
+
+Key metrics:
+  total_tvl       — sum of all tracked protocol TVLs
+  protocol rank   — top 10 by TVL, with 24h/7d change %
+  chain dominance — ETH/BSC/SOL/ARB share of total TVL
+  momentum        — TVL acceleration: accelerating/stable/declining
+  sparkline       — 30-day daily TVL series
+
+Momentum classification:
+  accelerating — 7d change rate > 5%
+  declining    — 7d change rate < -5%
+  stable       — otherwise
+
+Chain dominance: collapse chains < 3% TVL share into "Others"
+
+Covers:
+  - _dt_tvl_change_pct
+  - _dt_chain_dominance
+  - _dt_momentum_signal
+  - _dt_rank_protocols
+  - _dt_format_tvl
+  - _dt_category_breakdown
+  - _dt_dominance_others
+  - Response shape / key validation
+  - Structural: route, HTML card, JS function, JS API call
+"""
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from metrics import (
+    _dt_tvl_change_pct,
+    _dt_chain_dominance,
+    _dt_momentum_signal,
+    _dt_rank_protocols,
+    _dt_format_tvl,
+    _dt_category_breakdown,
+    _dt_dominance_others,
+)
+
+# ---------------------------------------------------------------------------
+# Sample response fixture
+# ---------------------------------------------------------------------------
+
+SAMPLE_RESPONSE = {
+    "total_tvl_usd":      95_000_000_000.0,
+    "tvl_change_24h_pct":  2.3,
+    "tvl_change_7d_pct":  -1.8,
+    "momentum":            "stable",
+    "protocols": [
+        {"name": "Lido",        "tvl_usd": 28_000_000_000.0, "chain": "Ethereum",  "category": "Liquid Staking", "change_24h_pct":  1.2, "change_7d_pct":  3.5},
+        {"name": "AAVE",        "tvl_usd": 12_000_000_000.0, "chain": "Multi",     "category": "Lending",        "change_24h_pct":  0.5, "change_7d_pct": -2.1},
+        {"name": "Uniswap",     "tvl_usd":  6_500_000_000.0, "chain": "Ethereum",  "category": "DEX",            "change_24h_pct":  3.1, "change_7d_pct":  1.0},
+        {"name": "Curve",       "tvl_usd":  5_800_000_000.0, "chain": "Multi",     "category": "DEX",            "change_24h_pct": -0.3, "change_7d_pct": -4.2},
+        {"name": "MakerDAO",    "tvl_usd":  5_200_000_000.0, "chain": "Ethereum",  "category": "CDP",            "change_24h_pct":  0.8, "change_7d_pct":  0.5},
+        {"name": "JustLend",    "tvl_usd":  4_700_000_000.0, "chain": "Tron",      "category": "Lending",        "change_24h_pct":  1.5, "change_7d_pct":  2.8},
+        {"name": "Kamino",      "tvl_usd":  3_200_000_000.0, "chain": "Solana",    "category": "Lending",        "change_24h_pct":  4.2, "change_7d_pct":  8.1},
+        {"name": "Eigen Layer", "tvl_usd":  3_000_000_000.0, "chain": "Ethereum",  "category": "Restaking",      "change_24h_pct":  0.0, "change_7d_pct": -1.2},
+        {"name": "PancakeSwap", "tvl_usd":  2_100_000_000.0, "chain": "BSC",       "category": "DEX",            "change_24h_pct":  1.9, "change_7d_pct":  3.3},
+        {"name": "GMX",         "tvl_usd":  1_800_000_000.0, "chain": "Arbitrum",  "category": "Derivatives",    "change_24h_pct":  2.7, "change_7d_pct":  5.9},
+    ],
+    "chain_dominance": {
+        "Ethereum": 58.2,
+        "BSC":       8.1,
+        "Solana":    6.4,
+        "Arbitrum":  5.2,
+        "Others":   22.1,
+    },
+    "history": [
+        {"date": "2024-11-14", "tvl_usd": 88_000_000_000.0},
+        {"date": "2024-11-15", "tvl_usd": 89_500_000_000.0},
+        {"date": "2024-11-16", "tvl_usd": 87_200_000_000.0},
+        {"date": "2024-11-17", "tvl_usd": 91_000_000_000.0},
+        {"date": "2024-11-18", "tvl_usd": 93_400_000_000.0},
+        {"date": "2024-11-19", "tvl_usd": 94_800_000_000.0},
+        {"date": "2024-11-20", "tvl_usd": 95_000_000_000.0},
+    ],
+    "description": "DeFi TVL $95B — stable momentum, ETH dominance 58%",
+}
+
+
+# ===========================================================================
+# 1. _dt_tvl_change_pct
+# ===========================================================================
+
+class TestDtTvlChangePct:
+    def test_increase_returns_positive(self):
+        assert _dt_tvl_change_pct(110.0, 100.0) == pytest.approx(10.0, rel=1e-4)
+
+    def test_decrease_returns_negative(self):
+        assert _dt_tvl_change_pct(90.0, 100.0) == pytest.approx(-10.0, rel=1e-4)
+
+    def test_no_change_returns_zero(self):
+        assert _dt_tvl_change_pct(100.0, 100.0) == pytest.approx(0.0, abs=1e-6)
+
+    def test_zero_previous_returns_zero(self):
+        assert _dt_tvl_change_pct(100.0, 0.0) == pytest.approx(0.0, abs=1e-6)
+
+    def test_zero_current_returns_minus_100(self):
+        assert _dt_tvl_change_pct(0.0, 100.0) == pytest.approx(-100.0, rel=1e-4)
+
+    def test_returns_float(self):
+        assert isinstance(_dt_tvl_change_pct(110.0, 100.0), float)
+
+    def test_large_increase(self):
+        pct = _dt_tvl_change_pct(200.0, 100.0)
+        assert pct == pytest.approx(100.0, rel=1e-4)
+
+
+# ===========================================================================
+# 2. _dt_chain_dominance
+# ===========================================================================
+
+class TestDtChainDominance:
+    def test_single_chain_is_100_pct(self):
+        result = _dt_chain_dominance({"Ethereum": 1_000_000.0})
+        assert result["Ethereum"] == pytest.approx(100.0, rel=1e-4)
+
+    def test_two_equal_chains_are_50_50(self):
+        result = _dt_chain_dominance({"Ethereum": 500.0, "BSC": 500.0})
+        assert result["Ethereum"] == pytest.approx(50.0, rel=1e-4)
+        assert result["BSC"]      == pytest.approx(50.0, rel=1e-4)
+
+    def test_percentages_sum_to_100(self):
+        chains = {"Ethereum": 600.0, "BSC": 200.0, "Solana": 150.0, "Arbitrum": 50.0}
+        result = _dt_chain_dominance(chains)
+        assert sum(result.values()) == pytest.approx(100.0, rel=1e-4)
+
+    def test_empty_returns_empty(self):
+        assert _dt_chain_dominance({}) == {}
+
+    def test_zero_total_returns_empty(self):
+        assert _dt_chain_dominance({"Ethereum": 0.0, "BSC": 0.0}) == {}
+
+    def test_values_in_0_100(self):
+        chains = {"A": 300.0, "B": 500.0, "C": 200.0}
+        for pct in _dt_chain_dominance(chains).values():
+            assert 0.0 <= pct <= 100.0
+
+    def test_proportional_output(self):
+        result = _dt_chain_dominance({"X": 750.0, "Y": 250.0})
+        assert result["X"] == pytest.approx(75.0, rel=1e-4)
+        assert result["Y"] == pytest.approx(25.0, rel=1e-4)
+
+
+# ===========================================================================
+# 3. _dt_momentum_signal
+# ===========================================================================
+
+class TestDtMomentumSignal:
+    def test_empty_returns_stable(self):
+        assert _dt_momentum_signal([]) == "stable"
+
+    def test_single_returns_stable(self):
+        assert _dt_momentum_signal([1e11]) == "stable"
+
+    def test_strongly_rising_series_is_accelerating(self):
+        # Start 50B, end 80B → +60%
+        series = [50e9, 55e9, 60e9, 65e9, 70e9, 75e9, 80e9]
+        assert _dt_momentum_signal(series) == "accelerating"
+
+    def test_strongly_falling_series_is_declining(self):
+        series = [80e9, 75e9, 70e9, 65e9, 60e9, 55e9, 50e9]
+        assert _dt_momentum_signal(series) == "declining"
+
+    def test_flat_series_is_stable(self):
+        series = [90e9] * 7
+        assert _dt_momentum_signal(series) == "stable"
+
+    def test_returns_valid_string(self):
+        result = _dt_momentum_signal([80e9, 82e9, 84e9])
+        assert result in ("accelerating", "stable", "declining")
+
+
+# ===========================================================================
+# 4. _dt_rank_protocols
+# ===========================================================================
+
+class TestDtRankProtocols:
+    PROTOCOLS = [
+        {"name": "A", "tvl_usd": 1_000.0},
+        {"name": "B", "tvl_usd": 5_000.0},
+        {"name": "C", "tvl_usd": 3_000.0},
+        {"name": "D", "tvl_usd": 2_000.0},
+        {"name": "E", "tvl_usd":   800.0},
+    ]
+
+    def test_returns_top_n(self):
+        result = _dt_rank_protocols(self.PROTOCOLS, 3)
+        assert len(result) == 3
+
+    def test_sorted_descending_by_tvl(self):
+        result = _dt_rank_protocols(self.PROTOCOLS, 5)
+        tvls = [p["tvl_usd"] for p in result]
+        assert tvls == sorted(tvls, reverse=True)
+
+    def test_first_is_highest_tvl(self):
+        result = _dt_rank_protocols(self.PROTOCOLS, 1)
+        assert result[0]["name"] == "B"
+
+    def test_empty_list_returns_empty(self):
+        assert _dt_rank_protocols([], 5) == []
+
+    def test_n_larger_than_list_returns_all(self):
+        result = _dt_rank_protocols(self.PROTOCOLS, 100)
+        assert len(result) == len(self.PROTOCOLS)
+
+    def test_preserves_protocol_fields(self):
+        result = _dt_rank_protocols(self.PROTOCOLS, 1)
+        assert "name" in result[0]
+        assert "tvl_usd" in result[0]
+
+
+# ===========================================================================
+# 5. _dt_format_tvl
+# ===========================================================================
+
+class TestDtFormatTvl:
+    def test_billions_formatted(self):
+        assert "B" in _dt_format_tvl(95_000_000_000.0)
+
+    def test_millions_formatted(self):
+        assert "M" in _dt_format_tvl(250_000_000.0)
+
+    def test_below_million_formatted(self):
+        result = _dt_format_tvl(500_000.0)
+        assert "K" in result or "$" in result
+
+    def test_zero_returns_string(self):
+        result = _dt_format_tvl(0.0)
+        assert isinstance(result, str)
+
+    def test_exact_billion(self):
+        result = _dt_format_tvl(1_000_000_000.0)
+        assert "1" in result and "B" in result
+
+    def test_returns_string(self):
+        assert isinstance(_dt_format_tvl(1_000_000_000.0), str)
+
+    def test_starts_with_dollar(self):
+        assert _dt_format_tvl(1_000_000_000.0).startswith("$")
+
+
+# ===========================================================================
+# 6. _dt_category_breakdown
+# ===========================================================================
+
+class TestDtCategoryBreakdown:
+    PROTOCOLS = [
+        {"name": "Lido",    "category": "Liquid Staking", "tvl_usd": 28e9},
+        {"name": "AAVE",    "category": "Lending",        "tvl_usd": 12e9},
+        {"name": "Uniswap", "category": "DEX",            "tvl_usd":  6.5e9},
+        {"name": "Curve",   "category": "DEX",            "tvl_usd":  5.8e9},
+        {"name": "Maker",   "category": "CDP",            "tvl_usd":  5.2e9},
+    ]
+
+    def test_returns_dict(self):
+        assert isinstance(_dt_category_breakdown(self.PROTOCOLS), dict)
+
+    def test_dex_sums_both_protocols(self):
+        result = _dt_category_breakdown(self.PROTOCOLS)
+        assert result["DEX"] == pytest.approx(6.5e9 + 5.8e9, rel=1e-4)
+
+    def test_all_categories_present(self):
+        result = _dt_category_breakdown(self.PROTOCOLS)
+        for cat in ("Liquid Staking", "Lending", "DEX", "CDP"):
+            assert cat in result
+
+    def test_empty_returns_empty(self):
+        assert _dt_category_breakdown([]) == {}
+
+    def test_missing_category_field_skipped(self):
+        protocols = [{"name": "X", "tvl_usd": 100.0}]  # no 'category'
+        result = _dt_category_breakdown(protocols)
+        assert isinstance(result, dict)
+
+    def test_values_are_floats(self):
+        result = _dt_category_breakdown(self.PROTOCOLS)
+        for v in result.values():
+            assert isinstance(v, float)
+
+
+# ===========================================================================
+# 7. _dt_dominance_others
+# ===========================================================================
+
+class TestDtDominanceOthers:
+    def test_small_chains_collapsed(self):
+        pcts = {"Ethereum": 60.0, "BSC": 10.0, "TinyChain": 2.0, "TinyChain2": 1.5}
+        result = _dt_dominance_others(pcts, threshold=3.0)
+        assert "Others" in result
+        assert "TinyChain" not in result
+
+    def test_large_chains_preserved(self):
+        pcts = {"Ethereum": 60.0, "BSC": 10.0, "Solana": 8.0}
+        result = _dt_dominance_others(pcts, threshold=3.0)
+        assert "Ethereum" in result
+        assert "BSC" in result
+        assert "Solana" in result
+
+    def test_others_sum_correct(self):
+        pcts = {"A": 60.0, "B": 25.0, "C": 10.0, "D": 5.0}
+        result = _dt_dominance_others(pcts, threshold=8.0)
+        # C (10%) survives, D (5%) collapses
+        assert result.get("Others", 0) == pytest.approx(5.0, rel=1e-4)
+
+    def test_empty_returns_empty(self):
+        assert _dt_dominance_others({}, threshold=3.0) == {}
+
+    def test_no_small_chains_no_others_key(self):
+        pcts = {"Ethereum": 60.0, "BSC": 40.0}
+        result = _dt_dominance_others(pcts, threshold=3.0)
+        assert "Others" not in result
+
+
+# ===========================================================================
+# 8. SAMPLE_RESPONSE structure
+# ===========================================================================
+
+class TestSampleResponseShape:
+    def test_has_total_tvl(self):
+        assert SAMPLE_RESPONSE["total_tvl_usd"] > 0
+
+    def test_has_24h_change(self):
+        assert "tvl_change_24h_pct" in SAMPLE_RESPONSE
+
+    def test_has_7d_change(self):
+        assert "tvl_change_7d_pct" in SAMPLE_RESPONSE
+
+    def test_has_momentum(self):
+        assert SAMPLE_RESPONSE["momentum"] in ("accelerating", "stable", "declining")
+
+    def test_has_protocols_list(self):
+        assert isinstance(SAMPLE_RESPONSE["protocols"], list)
+
+    def test_protocols_count_is_ten(self):
+        assert len(SAMPLE_RESPONSE["protocols"]) == 10
+
+    def test_each_protocol_has_required_keys(self):
+        for p in SAMPLE_RESPONSE["protocols"]:
+            for key in ("name", "tvl_usd", "chain", "category", "change_24h_pct", "change_7d_pct"):
+                assert key in p, f"protocol '{p.get('name')}' missing '{key}'"
+
+    def test_has_chain_dominance_dict(self):
+        assert isinstance(SAMPLE_RESPONSE["chain_dominance"], dict)
+
+    def test_chain_dominance_has_others(self):
+        assert "Others" in SAMPLE_RESPONSE["chain_dominance"]
+
+    def test_chain_dominance_sums_to_100(self):
+        total = sum(SAMPLE_RESPONSE["chain_dominance"].values())
+        assert total == pytest.approx(100.0, abs=0.5)
+
+    def test_has_history_list(self):
+        assert isinstance(SAMPLE_RESPONSE["history"], list)
+
+    def test_history_items_have_required_keys(self):
+        for item in SAMPLE_RESPONSE["history"]:
+            for key in ("date", "tvl_usd"):
+                assert key in item, f"history item missing '{key}'"
+
+    def test_has_description(self):
+        assert isinstance(SAMPLE_RESPONSE["description"], str)
+
+
+# ===========================================================================
+# 9. Structural tests
+# ===========================================================================
+
+class TestStructural:
+    def test_route_registered_in_api_py(self):
+        api_path = os.path.join(os.path.dirname(__file__), "..", "backend", "api.py")
+        content = open(api_path).read()
+        assert "/defi-tvl-tracker" in content, "/defi-tvl-tracker route missing"
+
+    def test_html_card_exists(self):
+        html_path = os.path.join(os.path.dirname(__file__), "..", "frontend", "index.html")
+        content = open(html_path).read()
+        assert "card-defi-tvl-tracker" in content, "card-defi-tvl-tracker missing"
+
+    def test_js_render_function_exists(self):
+        js_path = os.path.join(os.path.dirname(__file__), "..", "frontend", "app.js")
+        content = open(js_path).read()
+        assert "renderDefiTvlTracker" in content, "renderDefiTvlTracker missing"
+
+    def test_js_api_call_to_endpoint(self):
+        js_path = os.path.join(os.path.dirname(__file__), "..", "frontend", "app.js")
+        content = open(js_path).read()
+        assert "/defi-tvl-tracker" in content, "/defi-tvl-tracker call missing"


### PR DESCRIPTION
## Summary

- Adds DeFi TVL tracker card showing top 10 protocols by TVL change, chain dominance (ETH/BSC/SOL/ARB), and TVL momentum signal with 30-day sparkline
- **Protocol table**: top 5 visible (full 10 in API), with 24h and 7d % change color-coded
- **Chain dominance bar**: proportional colored bar with ETH/BSC/SOL/ARB/Others segments and legend
- **Momentum signal**: accelerating (>+5% 7d) / stable / declining (<-5% 7d)
- **30-day sparkline**: variable-height bars scaled to TVL range
- Realistic mock data layer (seeded random walk) when DeFi Llama API unavailable
- Data source: DeFi Llama public API — `/protocols`, `/chains`, `/v2/historicalChainTvl` (free, no auth)
- 61 tests

## Test plan

- [x] 61 tests: 7 tvl_change_pct, 7 chain_dominance, 6 momentum_signal, 6 rank_protocols, 7 format_tvl, 6 category_breakdown, 5 dominance_others, 13 response shape, 4 structural
- [x] `node --check frontend/app.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)