### PR TITLE
feat: protocol fee capture dashboard

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -72,6 +72,7 @@ from metrics import (
     compute_layer2_metrics,
     compute_nft_market_pulse,
     compute_cross_chain_bridge_monitor,
+    compute_protocol_fee_capture,
 )
 
 router = APIRouter(prefix="/api")
@@ -5326,4 +5327,11 @@ async def holder_distribution_endpoint():
 async def cross_chain_bridge_monitor_endpoint():
     """Cross-chain bridge monitor: flows across ETH/BSC/ARB/OP/BASE, top bridges, anomaly detection."""
     data = await compute_cross_chain_bridge_monitor()
+    return JSONResponse(data)
+
+
+@router.get("/protocol-fee-capture")
+async def protocol_fee_capture_endpoint():
+    """Protocol fee capture: top-20 DeFi fee revenue, P/S ratios, growth rates, fee-leader signal."""
+    data = await compute_protocol_fee_capture()
     return JSONResponse(data)

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -8537,3 +8537,125 @@ async def compute_cross_chain_bridge_monitor() -> dict:
         "zscore":           float(zscore),
         "description":      desc,
     }
+
+
+# ── Protocol Fee Capture ───────────────────────────────────────────────────────
+
+_PFC_PROTOCOLS = [
+    # name,       fee_24h_usd,  market_cap_usd
+    ("Uniswap",     3_850_000,   5_200_000_000),
+    ("Aave",        1_420_000,   1_800_000_000),
+    ("Lido",        2_100_000,   2_400_000_000),
+    ("GMX",           980_000,     620_000_000),
+    ("Curve",         760_000,     420_000_000),
+    ("MakerDAO",      640_000,   1_100_000_000),
+    ("Compound",      310_000,     520_000_000),
+    ("dYdX",          430_000,     380_000_000),
+    ("Synthetix",     260_000,     280_000_000),
+    ("Balancer",      195_000,     210_000_000),
+    ("Convex",        175_000,     260_000_000),
+    ("1inch",         140_000,     190_000_000),
+    ("Sushiswap",     120_000,     130_000_000),
+    ("Frax",          105_000,     180_000_000),
+    ("Pendle",         88_000,     140_000_000),
+    ("Yearn",          72_000,     160_000_000),
+    ("Velodrome",      65_000,      90_000_000),
+    ("Radiant",        58_000,      75_000_000),
+    ("Gains",          48_000,      65_000_000),
+    ("Camelot",        42_000,      55_000_000),
+]
+
+# 7-day growth rates (%) seeded per protocol
+_PFC_GROWTH_7D = {
+    "Uniswap":    12.40,
+    "Aave":        8.20,
+    "Lido":       15.60,
+    "GMX":        22.30,
+    "Curve":      -3.10,
+    "MakerDAO":    5.80,
+    "Compound":   -1.50,
+    "dYdX":       18.70,
+    "Synthetix":   4.20,
+    "Balancer":   -2.40,
+    "Convex":      6.90,
+    "1inch":       3.30,
+    "Sushiswap":  -5.60,
+    "Frax":        9.10,
+    "Pendle":     31.20,
+    "Yearn":      -0.80,
+    "Velodrome":  11.50,
+    "Radiant":    -4.30,
+    "Gains":       7.60,
+    "Camelot":    14.80,
+}
+
+# 7d/30d multipliers relative to 24h (slightly randomised but seeded)
+_PFC_7D_MULT = {
+    "Uniswap":   7.3, "Aave": 7.1, "Lido": 7.4, "GMX": 6.8, "Curve": 7.0,
+    "MakerDAO":  7.2, "Compound": 6.9, "dYdX": 7.5, "Synthetix": 7.0,
+    "Balancer":  6.8, "Convex": 7.1, "1inch": 7.2, "Sushiswap": 6.7,
+    "Frax":      7.0, "Pendle": 7.6, "Yearn": 6.9, "Velodrome": 7.3,
+    "Radiant":   6.8, "Gains": 7.1, "Camelot": 7.2,
+}
+_PFC_30D_MULT = {
+    "Uniswap":   30.4, "Aave": 30.1, "Lido": 31.0, "GMX": 29.5, "Curve": 29.8,
+    "MakerDAO":  30.6, "Compound": 29.3, "dYdX": 31.2, "Synthetix": 29.9,
+    "Balancer":  29.1, "Convex": 30.3, "1inch": 30.5, "Sushiswap": 28.9,
+    "Frax":      30.0, "Pendle": 31.8, "Yearn": 29.4, "Velodrome": 30.7,
+    "Radiant":   29.0, "Gains": 30.2, "Camelot": 30.9,
+}
+
+
+def _pfc_ps_ratio(market_cap: float, fee_30d: float) -> float:
+    """P/S = market_cap / annualized_fee_revenue (fee_30d * 12)."""
+    annualized = fee_30d * 12
+    if annualized <= 0:
+        return 0.0
+    return round(market_cap / annualized, 2)
+
+
+def _pfc_fee_leader_signal(top_share: float) -> str:
+    if top_share > 0.35:
+        return "dominant"
+    if top_share < 0.20:
+        return "fragmented"
+    return "neutral"
+
+
+async def compute_protocol_fee_capture(symbol: str = None) -> dict:
+    """
+    Protocol fee capture dashboard card.
+
+    Returns seeded 24h/7d/30d fee revenue for top-20 DeFi protocols,
+    P/S ratios, 7d growth rates, competitive ranking, and a fee-leader signal.
+    """
+    protocols = []
+    for name, fee_24h_raw, mcap in _PFC_PROTOCOLS:
+        fee_24h = round(float(fee_24h_raw), 2)
+        fee_7d  = round(fee_24h * _PFC_7D_MULT[name], 2)
+        fee_30d = round(fee_24h * _PFC_30D_MULT[name], 2)
+        ps      = _pfc_ps_ratio(float(mcap), fee_30d)
+        growth  = round(float(_PFC_GROWTH_7D[name]), 2)
+        protocols.append({
+            "name":          name,
+            "fee_24h":       fee_24h,
+            "fee_7d":        fee_7d,
+            "fee_30d":       fee_30d,
+            "ps_ratio":      ps,
+            "growth_rate_7d": growth,
+        })
+
+    # Sort by 24h fee descending (competitive rank)
+    protocols.sort(key=lambda p: p["fee_24h"], reverse=True)
+
+    top_protocol = protocols[0]["name"]
+    total_24h = round(sum(p["fee_24h"] for p in protocols), 2)
+    top_share = protocols[0]["fee_24h"] / total_24h if total_24h > 0 else 0.0
+    signal = _pfc_fee_leader_signal(top_share)
+
+    return {
+        "protocols":          protocols,
+        "top_protocol":       top_protocol,
+        "total_defi_fees_24h": total_24h,
+        "fee_leader_signal":  signal,
+    }

--- a/backend/tests/test_protocol_fee_capture.py
+++ b/backend/tests/test_protocol_fee_capture.py
@@ -1,0 +1,403 @@
+"""Tests for protocol fee capture metric — TDD first."""
+import os
+import sys
+import pytest
+
+os.environ.setdefault("DB_PATH", "/tmp/test_protocol_fee_capture.db")
+os.environ.setdefault("SYMBOL_BINANCE", "BANANAS31USDT")
+os.environ.setdefault("SYMBOL_BYBIT", "BANANAS31USDT")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from metrics import compute_protocol_fee_capture
+
+PROTOCOLS = [
+    "Uniswap", "Aave", "Compound", "Curve", "dYdX", "GMX", "Lido",
+    "MakerDAO", "Balancer", "Synthetix", "1inch", "Sushiswap", "Yearn",
+    "Convex", "Frax", "Pendle", "Velodrome", "Camelot", "Radiant", "Gains",
+]
+
+
+@pytest.mark.asyncio
+async def test_returns_dict():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert isinstance(result, dict)
+
+
+@pytest.mark.asyncio
+async def test_top_level_keys():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert "protocols" in result
+    assert "top_protocol" in result
+    assert "total_defi_fees_24h" in result
+    assert "fee_leader_signal" in result
+
+
+@pytest.mark.asyncio
+async def test_protocols_is_list():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert isinstance(result["protocols"], list)
+
+
+@pytest.mark.asyncio
+async def test_protocols_count():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert len(result["protocols"]) == 20
+
+
+@pytest.mark.asyncio
+async def test_protocol_entry_keys():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    p = result["protocols"][0]
+    assert "name" in p
+    assert "fee_24h" in p
+    assert "fee_7d" in p
+    assert "fee_30d" in p
+    assert "ps_ratio" in p
+    assert "growth_rate_7d" in p
+
+
+@pytest.mark.asyncio
+async def test_protocol_names_are_strings():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert isinstance(p["name"], str)
+        assert len(p["name"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_all_expected_protocols_present():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = {p["name"] for p in result["protocols"]}
+    for proto in PROTOCOLS:
+        assert proto in names, f"{proto} missing from protocols"
+
+
+@pytest.mark.asyncio
+async def test_fee_24h_positive():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_24h"] > 0, f"{p['name']} fee_24h should be positive"
+
+
+@pytest.mark.asyncio
+async def test_fee_7d_positive():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_7d"] > 0, f"{p['name']} fee_7d should be positive"
+
+
+@pytest.mark.asyncio
+async def test_fee_30d_positive():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_30d"] > 0, f"{p['name']} fee_30d should be positive"
+
+
+@pytest.mark.asyncio
+async def test_fee_7d_geq_fee_24h():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_7d"] >= p["fee_24h"], f"{p['name']} fee_7d < fee_24h"
+
+
+@pytest.mark.asyncio
+async def test_fee_30d_geq_fee_7d():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_30d"] >= p["fee_7d"], f"{p['name']} fee_30d < fee_7d"
+
+
+@pytest.mark.asyncio
+async def test_ps_ratio_positive():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["ps_ratio"] > 0, f"{p['name']} ps_ratio should be positive"
+
+
+@pytest.mark.asyncio
+async def test_growth_rate_7d_is_float():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert isinstance(p["growth_rate_7d"], float), f"{p['name']} growth_rate_7d not float"
+
+
+@pytest.mark.asyncio
+async def test_top_protocol_is_string():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert isinstance(result["top_protocol"], str)
+    assert len(result["top_protocol"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_top_protocol_is_in_list():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = {p["name"] for p in result["protocols"]}
+    assert result["top_protocol"] in names
+
+
+@pytest.mark.asyncio
+async def test_top_protocol_has_highest_fee_24h():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    top = result["top_protocol"]
+    top_fee = next(p["fee_24h"] for p in result["protocols"] if p["name"] == top)
+    max_fee = max(p["fee_24h"] for p in result["protocols"])
+    assert top_fee == max_fee
+
+
+@pytest.mark.asyncio
+async def test_total_defi_fees_24h_positive():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert result["total_defi_fees_24h"] > 0
+
+
+@pytest.mark.asyncio
+async def test_total_defi_fees_24h_is_sum():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    expected = round(sum(p["fee_24h"] for p in result["protocols"]), 2)
+    assert abs(result["total_defi_fees_24h"] - expected) < 0.1
+
+
+@pytest.mark.asyncio
+async def test_fee_leader_signal_valid_values():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert result["fee_leader_signal"] in ("dominant", "fragmented", "neutral")
+
+
+@pytest.mark.asyncio
+async def test_dominant_signal_when_top_protocol_large_share():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    top = result["top_protocol"]
+    top_fee = next(p["fee_24h"] for p in result["protocols"] if p["name"] == top)
+    total = result["total_defi_fees_24h"]
+    share = top_fee / total if total > 0 else 0
+    if share > 0.35:
+        assert result["fee_leader_signal"] == "dominant"
+
+
+@pytest.mark.asyncio
+async def test_protocols_sorted_by_fee_24h_desc():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    fees = [p["fee_24h"] for p in result["protocols"]]
+    assert fees == sorted(fees, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_uniswap_in_top5():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    top5_names = [p["name"] for p in result["protocols"][:5]]
+    assert "Uniswap" in top5_names
+
+
+@pytest.mark.asyncio
+async def test_fee_24h_uniswap_gt_1m():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    uni = next(p for p in result["protocols"] if p["name"] == "Uniswap")
+    assert uni["fee_24h"] > 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_fee_7d_approx_7x_24h():
+    """7d fees should be roughly 5-10x the 24h fees."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        ratio = p["fee_7d"] / p["fee_24h"]
+        assert 4 <= ratio <= 12, f"{p['name']} fee_7d/fee_24h ratio {ratio:.2f} out of range"
+
+
+@pytest.mark.asyncio
+async def test_fee_30d_approx_30x_24h():
+    """30d fees should be roughly 20-40x the 24h fees."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        ratio = p["fee_30d"] / p["fee_24h"]
+        assert 18 <= ratio <= 45, f"{p['name']} fee_30d/fee_24h ratio {ratio:.2f} out of range"
+
+
+@pytest.mark.asyncio
+async def test_ps_ratio_reasonable_range():
+    """P/S ratios for DeFi protocols should be between 1 and 1000."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert 1 <= p["ps_ratio"] <= 1000, f"{p['name']} ps_ratio {p['ps_ratio']} out of range"
+
+
+@pytest.mark.asyncio
+async def test_growth_rate_7d_range():
+    """Growth rate should be between -100% and +500%."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert -100 <= p["growth_rate_7d"] <= 500, (
+            f"{p['name']} growth_rate_7d {p['growth_rate_7d']} out of range"
+        )
+
+
+@pytest.mark.asyncio
+async def test_idempotent_same_symbol():
+    """Two calls with same symbol should return same top_protocol."""
+    r1 = await compute_protocol_fee_capture("BANANAS31USDT")
+    r2 = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert r1["top_protocol"] == r2["top_protocol"]
+
+
+@pytest.mark.asyncio
+async def test_different_symbol_returns_same_structure():
+    """Different symbol arg should still return valid structure."""
+    result = await compute_protocol_fee_capture("COSUSDT")
+    assert "protocols" in result
+    assert len(result["protocols"]) == 20
+
+
+@pytest.mark.asyncio
+async def test_total_fees_24h_is_float():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert isinstance(result["total_defi_fees_24h"], float)
+
+
+@pytest.mark.asyncio
+async def test_fee_values_are_floats():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert isinstance(p["fee_24h"], float)
+        assert isinstance(p["fee_7d"], float)
+        assert isinstance(p["fee_30d"], float)
+        assert isinstance(p["ps_ratio"], float)
+
+
+@pytest.mark.asyncio
+async def test_no_none_values_in_protocol():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        for key, val in p.items():
+            assert val is not None, f"{p['name']}.{key} is None"
+
+
+@pytest.mark.asyncio
+async def test_top_protocol_not_empty_string():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert result["top_protocol"] != ""
+
+
+@pytest.mark.asyncio
+async def test_total_fees_24h_gt_1m():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert result["total_defi_fees_24h"] > 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_aave_present():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = [p["name"] for p in result["protocols"]]
+    assert "Aave" in names
+
+
+@pytest.mark.asyncio
+async def test_lido_present():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = [p["name"] for p in result["protocols"]]
+    assert "Lido" in names
+
+
+@pytest.mark.asyncio
+async def test_gmx_present():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = [p["name"] for p in result["protocols"]]
+    assert "GMX" in names
+
+
+@pytest.mark.asyncio
+async def test_growth_rate_7d_rounded():
+    """Growth rate should be rounded to 2 decimal places."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["growth_rate_7d"] == round(p["growth_rate_7d"], 2)
+
+
+@pytest.mark.asyncio
+async def test_ps_ratio_rounded():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["ps_ratio"] == round(p["ps_ratio"], 2)
+
+
+@pytest.mark.asyncio
+async def test_fee_24h_rounded():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_24h"] == round(p["fee_24h"], 2)
+
+
+@pytest.mark.asyncio
+async def test_fee_7d_rounded():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_7d"] == round(p["fee_7d"], 2)
+
+
+@pytest.mark.asyncio
+async def test_fee_30d_rounded():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert p["fee_30d"] == round(p["fee_30d"], 2)
+
+
+@pytest.mark.asyncio
+async def test_fragmented_signal_when_no_dominant():
+    """If no protocol has >35% share and top share <20%, signal should be fragmented."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    top = result["top_protocol"]
+    top_fee = next(p["fee_24h"] for p in result["protocols"] if p["name"] == top)
+    total = result["total_defi_fees_24h"]
+    share = top_fee / total if total > 0 else 0
+    if share < 0.20:
+        assert result["fee_leader_signal"] == "fragmented"
+
+
+@pytest.mark.asyncio
+async def test_protocol_names_unique():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    names = [p["name"] for p in result["protocols"]]
+    assert len(names) == len(set(names))
+
+
+@pytest.mark.asyncio
+async def test_uniswap_fee_24h_deterministic():
+    """Seeded simulation: Uniswap fee_24h should be the same across calls."""
+    r1 = await compute_protocol_fee_capture("BANANAS31USDT")
+    r2 = await compute_protocol_fee_capture("BANANAS31USDT")
+    uni1 = next(p["fee_24h"] for p in r1["protocols"] if p["name"] == "Uniswap")
+    uni2 = next(p["fee_24h"] for p in r2["protocols"] if p["name"] == "Uniswap")
+    assert uni1 == uni2
+
+
+@pytest.mark.asyncio
+async def test_gmx_fee_greater_than_gains():
+    """GMX (derivatives DEX) should have higher fee than Gains by seed."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    gmx = next(p["fee_24h"] for p in result["protocols"] if p["name"] == "GMX")
+    gains = next(p["fee_24h"] for p in result["protocols"] if p["name"] == "Gains")
+    assert gmx > gains
+
+
+@pytest.mark.asyncio
+async def test_fee_leader_signal_type():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    assert isinstance(result["fee_leader_signal"], str)
+
+
+@pytest.mark.asyncio
+async def test_protocols_entry_count_exactly_6_fields():
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        assert len(p) == 6, f"{p['name']} has {len(p)} fields, expected 6"
+
+
+@pytest.mark.asyncio
+async def test_annualized_fees_implied_by_ps():
+    """ps_ratio = market_cap / annualized_fees; annualized ~ fee_30d * 12."""
+    result = await compute_protocol_fee_capture("BANANAS31USDT")
+    for p in result["protocols"]:
+        annualized = p["fee_30d"] * 12
+        implied_mcap = p["ps_ratio"] * annualized
+        # Market cap should be > 0
+        assert implied_mcap > 0

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2502,6 +2502,8 @@ async function refresh() {
     // Batch 16: derivatives heatmap
         // Batch 25: holder distribution card
         // Batch 26: cross-chain bridge monitor
+    // Batch 27: protocol fee capture
+    await Promise.all([safe(renderProtocolFeeCapture)]);
   } finally {
     _refreshRunning = false;
   }
@@ -2747,6 +2749,65 @@ async function renderTokenVelocityNvt() {
 
 // ── Derivatives Heatmap ───────────────────────────────────────────────────────
 // ── Holder Distribution ───────────────────────────────────────────────────
+// ── Protocol Fee Capture ─────────────────────────────────────────────────────
+async function renderProtocolFeeCapture() {
+  const el    = document.getElementById('protocol-fee-capture-content');
+  const badge = document.getElementById('protocol-fee-capture-badge');
+  if (!el) return;
+  const data = await apiFetch('/protocol-fee-capture');
+  if (!data) { el.innerHTML = '<div style="color:var(--red);font-size:11px;">Error loading</div>'; return; }
+
+  const protos  = data.protocols || [];
+  const signal  = data.fee_leader_signal || 'neutral';
+  const total   = data.total_defi_fees_24h || 0;
+  const topName = data.top_protocol || '';
+
+  const sigCol = signal === 'dominant' ? 'var(--green)' : signal === 'fragmented' ? 'var(--yellow)' : 'var(--muted)';
+  if (badge) {
+    badge.textContent = signal.toUpperCase();
+    badge.style.background = sigCol;
+    badge.style.color = '#000';
+    badge.style.display = 'inline-block';
+  }
+
+  const fmtFee = v => {
+    if (v >= 1e6) return '$' + (v / 1e6).toFixed(2) + 'M';
+    if (v >= 1e3) return '$' + (v / 1e3).toFixed(1) + 'K';
+    return '$' + v.toFixed(0);
+  };
+
+  const top5 = protos.slice(0, 5);
+  const maxFee = top5[0] ? top5[0].fee_24h : 1;
+
+  const rows = top5.map((p, i) => {
+    const barW = Math.round((p.fee_24h / maxFee) * 100);
+    const growthCol = p.growth_rate_7d >= 0 ? 'var(--green)' : 'var(--red)';
+    const growthStr = (p.growth_rate_7d >= 0 ? '+' : '') + p.growth_rate_7d.toFixed(1) + '%';
+    const isTop = p.name === topName;
+    return `<div style="margin-bottom:5px">
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:2px">
+        <span style="font-size:9px;color:var(--muted);width:14px;text-align:right">${i + 1}</span>
+        <span style="font-size:10px;color:${isTop ? 'var(--green)' : 'var(--fg)'};width:72px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${p.name}</span>
+        <div style="flex:1;background:var(--border);height:6px;border-radius:3px">
+          <div style="width:${barW}%;background:${isTop ? 'var(--green)' : 'var(--accent)'};height:100%;border-radius:3px"></div>
+        </div>
+        <span style="font-size:10px;color:var(--fg);min-width:52px;text-align:right">${fmtFee(p.fee_24h)}</span>
+        <span style="font-size:9px;color:${growthCol};min-width:40px;text-align:right">${growthStr}</span>
+        <span style="font-size:9px;color:var(--muted);min-width:36px;text-align:right">P/S ${p.ps_ratio.toFixed(0)}x</span>
+      </div>
+    </div>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);margin-bottom:6px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>total 24h: <b style="color:var(--fg)">${fmtFee(total)}</b></span>
+      <span>leader: <b style="color:var(--green)">${topName}</b></span>
+      <span>signal: <b style="color:${sigCol}">${signal}</b></span>
+    </div>
+    ${rows}
+    <div style="font-size:9px;color:var(--muted);margin-top:4px">top-5 of 20 · sorted by 24h fee revenue · P/S = mktcap / annualized fees</div>`;
+}
+
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 async function init() {
   const safeInit = (fn) => { try { fn(); } catch(e) { console.warn('Chart init failed:', e.message); } };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -544,6 +544,18 @@
     </div>
   </section>
 
+  <!-- Protocol Fee Capture -->
+  <section class="card" id="card-protocol-fee-capture">
+    <div class="card-header">
+      <span class="card-title">Protocol Fee Capture</span>
+      <span id="protocol-fee-capture-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">top-20 DeFi · 24h/7d/30d · P/S ratio · growth</span>
+    </div>
+    <div id="protocol-fee-capture-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- WebSocket Stats -->
   <section class="card" id="card-ws-stats">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- Add `compute_protocol_fee_capture()` to `backend/metrics.py` — seeded fee revenue for top-20 DeFi protocols (Uniswap, Aave, Lido, GMX, …), P/S ratios, 7d growth rates, and fee-leader signal (dominant/fragmented/neutral)
- Add `GET /api/protocol-fee-capture` endpoint to `backend/api.py`
- Add 50 TDD tests in `backend/tests/test_protocol_fee_capture.py` (all passing)
- Add frontend card to `frontend/index.html` + `frontend/app.js` — top-5 bar chart, growth %, P/S, and signal badge

## Test plan
- [ ] `pytest tests/test_protocol_fee_capture.py` — 50/50 pass
- [ ] `GET /api/protocol-fee-capture` returns 20 protocols with correct fields
- [ ] Dashboard card renders with fee bars, growth rate, and badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)