### PR TITLE
feat: on-chain transaction velocity tracker

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -72,6 +72,7 @@ from metrics import (
     compute_layer2_metrics,
     compute_nft_market_pulse,
     compute_cross_chain_bridge_monitor,
+    compute_on_chain_tx_velocity,
 )
 
 router = APIRouter(prefix="/api")
@@ -5326,4 +5327,11 @@ async def holder_distribution_endpoint():
 async def cross_chain_bridge_monitor_endpoint():
     """Cross-chain bridge monitor: flows across ETH/BSC/ARB/OP/BASE, top bridges, anomaly detection."""
     data = await compute_cross_chain_bridge_monitor()
+    return JSONResponse(data)
+
+
+@router.get("/on-chain-tx-velocity")
+async def on_chain_tx_velocity_endpoint(symbol: str = Query(default="BANANAS31USDT")):
+    """On-chain transaction velocity: TPS trend for ETH/SOL/BNB, fee revenue, congestion index."""
+    data = await compute_on_chain_tx_velocity(symbol)
     return JSONResponse(data)

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -8537,3 +8537,142 @@ async def compute_cross_chain_bridge_monitor() -> dict:
         "zscore":           float(zscore),
         "description":      desc,
     }
+
+
+# ─── On-Chain Transaction Velocity ──────────────────────────────────────────
+
+# Base TPS per chain (approximate real-world values)
+_OCTV_BASE_TPS: dict = {"ETH": 15.0, "SOL": 3_000.0, "BNB": 100.0}
+# Max theoretical TPS per chain
+_OCTV_MAX_TPS: dict  = {"ETH": 50.0,  "SOL": 65_000.0, "BNB": 300.0}
+# Average fee per transaction in USD
+_OCTV_FEE_PER_TX: dict  = {"ETH": 5.0, "SOL": 0.00025, "BNB": 0.08}
+# Block time in seconds
+_OCTV_BLOCK_TIME: dict  = {"ETH": 12.0, "SOL": 0.4, "BNB": 3.0}
+# Average transaction value in USD
+_OCTV_AVG_TX_USD: dict  = {"ETH": 850.0, "SOL": 120.0, "BNB": 300.0}
+# Deterministic seeds per tracked symbol
+_OCTV_SYMBOL_SEEDS: dict = {
+    "BANANAS31USDT": 1001,
+    "COSUSDT":        1002,
+    "DEXEUSDT":       1003,
+    "LYNUSDT":        1004,
+}
+
+
+def _octv_seed_for_symbol(symbol: str) -> int:
+    """Return a deterministic integer seed for the given symbol."""
+    return _OCTV_SYMBOL_SEEDS.get(symbol, sum(ord(c) for c in symbol))
+
+
+def _octv_tps(chain: str, rng) -> float:
+    """TPS for *chain* with ±20 % seeded variation."""
+    base = _OCTV_BASE_TPS.get(chain, 10.0)
+    variation = rng.uniform(-0.20, 0.20)
+    return round(base * (1.0 + variation), 2)
+
+
+def _octv_fee_revenue_per_block(chain: str, tps: float) -> float:
+    """Fee revenue per block in USD: fee_per_tx × txs_per_block."""
+    fee       = _OCTV_FEE_PER_TX.get(chain, 0.1)
+    block_t   = _OCTV_BLOCK_TIME.get(chain, 12.0)
+    txs_block = tps * block_t
+    return round(txs_block * fee, 4)
+
+
+def _octv_avg_tx_value(chain: str, rng) -> float:
+    """Average transaction value in USD with ±15 % seeded variation."""
+    base      = _OCTV_AVG_TX_USD.get(chain, 100.0)
+    variation = rng.uniform(-0.15, 0.15)
+    return round(base * (1.0 + variation), 2)
+
+
+def _octv_congestion_index(tps: float, chain: str) -> float:
+    """Congestion index 0–100 based on TPS vs theoretical max capacity."""
+    max_tps = _OCTV_MAX_TPS.get(chain, 100.0)
+    if max_tps <= 0:
+        return 0.0
+    raw = max(tps, 0.0) / max_tps * 100.0
+    return round(min(raw, 100.0), 2)
+
+
+def _octv_throughput_percentile(tps_history: list, current_tps: float) -> float:
+    """Percentile rank of *current_tps* within *tps_history* (0–100)."""
+    if not tps_history:
+        return 50.0
+    below = sum(1 for v in tps_history if v <= current_tps)
+    return round(below / len(tps_history) * 100.0, 2)
+
+
+def _octv_trend(tps_history: list) -> str:
+    """Classify TPS trend as 'rising', 'falling', or 'stable'."""
+    if len(tps_history) < 2:
+        return "stable"
+    mid        = len(tps_history) // 2
+    first_half = tps_history[:mid]
+    second_half = tps_history[mid:]
+    avg_first  = sum(first_half)  / len(first_half)
+    avg_second = sum(second_half) / len(second_half)
+    if avg_second > avg_first * 1.02:
+        return "rising"
+    if avg_second < avg_first * 0.98:
+        return "falling"
+    return "stable"
+
+
+async def compute_on_chain_tx_velocity(symbol: str = "BANANAS31USDT") -> dict:
+    """
+    On-chain transaction velocity tracker for ETH/SOL/BNB.
+
+    Returns seeded-simulation data (no external calls):
+      eth_tps, sol_tps, bnb_tps, fee_revenue_block (USD), avg_tx_value (USD),
+      congestion_index (0-100), throughput_percentile (0-100),
+      trend (rising/stable/falling), tps_history_24h (list of 24 dicts).
+    """
+    import random as _rand  # noqa: PLC0415
+
+    seed = _octv_seed_for_symbol(symbol)
+    rng  = _rand.Random(seed)
+
+    # Current TPS per chain
+    eth_tps = _octv_tps("ETH", rng)
+    sol_tps = _octv_tps("SOL", rng)
+    bnb_tps = _octv_tps("BNB", rng)
+
+    # Fee revenue per block (ETH-denominated as primary)
+    fee_revenue_block = _octv_fee_revenue_per_block("ETH", eth_tps)
+
+    # Average tx value (ETH as primary chain)
+    avg_tx_value = _octv_avg_tx_value("ETH", rng)
+
+    # Congestion index based on ETH
+    congestion_index = _octv_congestion_index(eth_tps, "ETH")
+
+    # Build 24h hourly history with a separate rng stream
+    hist_rng = _rand.Random(seed + 100)
+    tps_history_24h: list = []
+    eth_history: list     = []
+    for _ in range(24):
+        h_eth = _octv_tps("ETH", hist_rng)
+        h_sol = _octv_tps("SOL", hist_rng)
+        h_bnb = _octv_tps("BNB", hist_rng)
+        eth_history.append(h_eth)
+        tps_history_24h.append({"eth": h_eth, "sol": h_sol, "bnb": h_bnb})
+
+    # Throughput percentile for ETH
+    throughput_percentile = _octv_throughput_percentile(eth_history, eth_tps)
+
+    # Trend direction
+    trend = _octv_trend(eth_history)
+
+    return {
+        "eth_tps":               eth_tps,
+        "sol_tps":               sol_tps,
+        "bnb_tps":               bnb_tps,
+        "fee_revenue_block":     fee_revenue_block,
+        "avg_tx_value":          avg_tx_value,
+        "congestion_index":      congestion_index,
+        "throughput_percentile": throughput_percentile,
+        "trend":                 trend,
+        "tps_history_24h":       tps_history_24h,
+    }

--- a/backend/tests/test_on_chain_tx_velocity.py
+++ b/backend/tests/test_on_chain_tx_velocity.py
@@ -1,0 +1,454 @@
+"""
+Unit tests for compute_on_chain_tx_velocity and its helper functions.
+
+On-chain transaction velocity tracker — ETH/SOL/BNB TPS, fee revenue,
+congestion index, throughput percentile, 24h history.
+
+Covers:
+  - _octv_seed_for_symbol
+  - _octv_tps
+  - _octv_fee_revenue_per_block
+  - _octv_avg_tx_value
+  - _octv_congestion_index
+  - _octv_throughput_percentile
+  - _octv_trend
+  - compute_on_chain_tx_velocity (async, full response shape)
+"""
+
+import sys
+import os
+import math
+import random
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from metrics import (
+    _octv_seed_for_symbol,
+    _octv_tps,
+    _octv_fee_revenue_per_block,
+    _octv_avg_tx_value,
+    _octv_congestion_index,
+    _octv_throughput_percentile,
+    _octv_trend,
+    compute_on_chain_tx_velocity,
+)
+
+
+# ===========================================================================
+# 1. _octv_seed_for_symbol
+# ===========================================================================
+
+class TestOctvSeedForSymbol:
+    def test_returns_int(self):
+        assert isinstance(_octv_seed_for_symbol("BANANAS31USDT"), int)
+
+    def test_known_symbols_return_different_seeds(self):
+        seeds = {_octv_seed_for_symbol(s) for s in
+                 ("BANANAS31USDT", "COSUSDT", "DEXEUSDT", "LYNUSDT")}
+        assert len(seeds) == 4
+
+    def test_same_symbol_same_seed(self):
+        assert _octv_seed_for_symbol("COSUSDT") == _octv_seed_for_symbol("COSUSDT")
+
+    def test_unknown_symbol_returns_int(self):
+        assert isinstance(_octv_seed_for_symbol("XYZUSDT"), int)
+
+    def test_unknown_symbol_non_zero(self):
+        # sum of ord chars for a non-empty string is > 0
+        assert _octv_seed_for_symbol("XYZUSDT") > 0
+
+
+# ===========================================================================
+# 2. _octv_tps
+# ===========================================================================
+
+class TestOctvTps:
+    def _rng(self, seed: int = 42) -> random.Random:
+        return random.Random(seed)
+
+    def test_eth_tps_positive(self):
+        assert _octv_tps("ETH", self._rng()) > 0.0
+
+    def test_sol_tps_positive(self):
+        assert _octv_tps("SOL", self._rng()) > 0.0
+
+    def test_bnb_tps_positive(self):
+        assert _octv_tps("BNB", self._rng()) > 0.0
+
+    def test_sol_tps_much_greater_than_eth(self):
+        rng1 = self._rng(1)
+        rng2 = self._rng(1)
+        eth = _octv_tps("ETH", rng1)
+        sol = _octv_tps("SOL", rng2)
+        assert sol > eth * 10
+
+    def test_bnb_tps_greater_than_eth(self):
+        rng1 = self._rng(2)
+        rng2 = self._rng(2)
+        eth = _octv_tps("ETH", rng1)
+        bnb = _octv_tps("BNB", rng2)
+        assert bnb > eth
+
+    def test_returns_float(self):
+        assert isinstance(_octv_tps("ETH", self._rng()), float)
+
+    def test_eth_tps_within_expected_range(self):
+        # ETH base ~15, ±20% → [12, 18]
+        for seed in range(10):
+            val = _octv_tps("ETH", random.Random(seed))
+            assert 5.0 <= val <= 50.0
+
+    def test_different_rng_seeds_different_values(self):
+        vals = {_octv_tps("ETH", random.Random(s)) for s in range(5)}
+        assert len(vals) > 1
+
+
+# ===========================================================================
+# 3. _octv_fee_revenue_per_block
+# ===========================================================================
+
+class TestOctvFeeRevenuePerBlock:
+    def test_eth_fee_revenue_positive(self):
+        assert _octv_fee_revenue_per_block("ETH", 15.0) > 0.0
+
+    def test_sol_fee_revenue_positive(self):
+        assert _octv_fee_revenue_per_block("SOL", 3000.0) > 0.0
+
+    def test_bnb_fee_revenue_positive(self):
+        assert _octv_fee_revenue_per_block("BNB", 100.0) > 0.0
+
+    def test_eth_fee_revenue_greater_than_sol(self):
+        eth_rev = _octv_fee_revenue_per_block("ETH", 15.0)
+        sol_rev = _octv_fee_revenue_per_block("SOL", 3000.0)
+        # ETH has much higher fee per tx ($5 vs $0.00025), so per-block dominates
+        assert eth_rev > sol_rev
+
+    def test_zero_tps_returns_zero(self):
+        assert _octv_fee_revenue_per_block("ETH", 0.0) == pytest.approx(0.0, abs=1e-9)
+
+    def test_higher_tps_higher_fee_revenue(self):
+        low  = _octv_fee_revenue_per_block("ETH", 10.0)
+        high = _octv_fee_revenue_per_block("ETH", 30.0)
+        assert high > low
+
+    def test_returns_float(self):
+        assert isinstance(_octv_fee_revenue_per_block("ETH", 15.0), float)
+
+    def test_proportional_to_tps(self):
+        rev_10 = _octv_fee_revenue_per_block("ETH", 10.0)
+        rev_20 = _octv_fee_revenue_per_block("ETH", 20.0)
+        assert rev_20 == pytest.approx(rev_10 * 2.0, rel=1e-4)
+
+
+# ===========================================================================
+# 4. _octv_avg_tx_value
+# ===========================================================================
+
+class TestOctvAvgTxValue:
+    def _rng(self, seed: int = 42) -> random.Random:
+        return random.Random(seed)
+
+    def test_eth_avg_tx_value_positive(self):
+        assert _octv_avg_tx_value("ETH", self._rng()) > 0.0
+
+    def test_sol_avg_tx_value_positive(self):
+        assert _octv_avg_tx_value("SOL", self._rng()) > 0.0
+
+    def test_bnb_avg_tx_value_positive(self):
+        assert _octv_avg_tx_value("BNB", self._rng()) > 0.0
+
+    def test_eth_avg_greater_than_sol(self):
+        eth = _octv_avg_tx_value("ETH", self._rng(7))
+        sol = _octv_avg_tx_value("SOL", self._rng(7))
+        # ETH base ~$850, SOL base ~$120
+        assert eth > sol
+
+    def test_returns_float(self):
+        assert isinstance(_octv_avg_tx_value("ETH", self._rng()), float)
+
+    def test_within_reasonable_range(self):
+        # ETH base ~$850 ±15%
+        for seed in range(5):
+            val = _octv_avg_tx_value("ETH", random.Random(seed))
+            assert 500.0 <= val <= 1500.0
+
+
+# ===========================================================================
+# 5. _octv_congestion_index
+# ===========================================================================
+
+class TestOctvCongestionIndex:
+    def test_zero_tps_returns_zero(self):
+        assert _octv_congestion_index(0.0, "ETH") == pytest.approx(0.0, abs=1e-9)
+
+    def test_returns_float(self):
+        assert isinstance(_octv_congestion_index(15.0, "ETH"), float)
+
+    def test_result_0_to_100(self):
+        for tps in (0.0, 10.0, 30.0, 50.0, 100.0):
+            val = _octv_congestion_index(tps, "ETH")
+            assert 0.0 <= val <= 100.0
+
+    def test_higher_tps_higher_congestion(self):
+        low  = _octv_congestion_index(5.0,  "ETH")
+        high = _octv_congestion_index(40.0, "ETH")
+        assert high > low
+
+    def test_max_tps_clamps_to_100(self):
+        # passing TPS >> max
+        val = _octv_congestion_index(1_000_000.0, "ETH")
+        assert val == pytest.approx(100.0, abs=1e-6)
+
+    def test_sol_congestion_positive(self):
+        assert _octv_congestion_index(3000.0, "SOL") > 0.0
+
+    def test_bnb_congestion_within_range(self):
+        val = _octv_congestion_index(100.0, "BNB")
+        assert 0.0 <= val <= 100.0
+
+    def test_never_negative(self):
+        assert _octv_congestion_index(-5.0, "ETH") >= 0.0
+
+
+# ===========================================================================
+# 6. _octv_throughput_percentile
+# ===========================================================================
+
+class TestOctvThroughputPercentile:
+    def test_empty_history_returns_50(self):
+        assert _octv_throughput_percentile([], 15.0) == pytest.approx(50.0, rel=1e-4)
+
+    def test_current_above_all_returns_100(self):
+        hist = [5.0, 10.0, 12.0]
+        assert _octv_throughput_percentile(hist, 20.0) == pytest.approx(100.0, rel=1e-4)
+
+    def test_current_below_all_returns_low(self):
+        hist = [10.0, 20.0, 30.0]
+        result = _octv_throughput_percentile(hist, 1.0)
+        assert result < 50.0
+
+    def test_returns_float(self):
+        assert isinstance(_octv_throughput_percentile([5.0, 10.0], 7.0), float)
+
+    def test_result_0_to_100(self):
+        for curr in (0.0, 5.0, 15.0, 50.0):
+            val = _octv_throughput_percentile([5.0, 10.0, 20.0], curr)
+            assert 0.0 <= val <= 100.0
+
+    def test_monotone_with_current_tps(self):
+        hist = [5.0, 10.0, 15.0, 20.0]
+        p1 = _octv_throughput_percentile(hist, 7.0)
+        p2 = _octv_throughput_percentile(hist, 12.0)
+        p3 = _octv_throughput_percentile(hist, 18.0)
+        assert p1 <= p2 <= p3
+
+    def test_single_element_history(self):
+        val = _octv_throughput_percentile([10.0], 10.0)
+        assert 0.0 <= val <= 100.0
+
+
+# ===========================================================================
+# 7. _octv_trend
+# ===========================================================================
+
+class TestOctvTrend:
+    def test_rising_values_returns_rising(self):
+        history = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]
+        assert _octv_trend(history) == "rising"
+
+    def test_falling_values_returns_falling(self):
+        history = [20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0, 11.0]
+        assert _octv_trend(history) == "falling"
+
+    def test_stable_values_returns_stable(self):
+        history = [15.0] * 10
+        assert _octv_trend(history) == "stable"
+
+    def test_empty_list_returns_stable(self):
+        assert _octv_trend([]) == "stable"
+
+    def test_single_value_returns_stable(self):
+        assert _octv_trend([15.0]) == "stable"
+
+    def test_two_equal_values_returns_stable(self):
+        assert _octv_trend([15.0, 15.0]) == "stable"
+
+    def test_returns_valid_string(self):
+        for h in ([10.0, 20.0], [20.0, 10.0], [15.0, 15.0]):
+            assert _octv_trend(h) in ("rising", "stable", "falling")
+
+    def test_strongly_rising_detects_rising(self):
+        # second half avg >> first half avg
+        history = [5.0, 5.0, 5.0, 5.0, 5.0, 20.0, 20.0, 20.0, 20.0, 20.0]
+        assert _octv_trend(history) == "rising"
+
+    def test_strongly_falling_detects_falling(self):
+        history = [20.0, 20.0, 20.0, 20.0, 20.0, 5.0, 5.0, 5.0, 5.0, 5.0]
+        assert _octv_trend(history) == "falling"
+
+
+# ===========================================================================
+# 8. compute_on_chain_tx_velocity (async, full response)
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_returns_dict():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert isinstance(result, dict)
+
+
+@pytest.mark.asyncio
+async def test_has_required_keys():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    for key in ("eth_tps", "sol_tps", "bnb_tps", "fee_revenue_block",
+                "avg_tx_value", "congestion_index", "throughput_percentile",
+                "trend", "tps_history_24h"):
+        assert key in result, f"Missing key: {key}"
+
+
+@pytest.mark.asyncio
+async def test_eth_tps_positive():
+    result = await compute_on_chain_tx_velocity("COSUSDT")
+    assert result["eth_tps"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_sol_tps_positive():
+    result = await compute_on_chain_tx_velocity("COSUSDT")
+    assert result["sol_tps"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_bnb_tps_positive():
+    result = await compute_on_chain_tx_velocity("DEXEUSDT")
+    assert result["bnb_tps"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_sol_tps_greater_than_eth():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert result["sol_tps"] > result["eth_tps"]
+
+
+@pytest.mark.asyncio
+async def test_bnb_tps_greater_than_eth():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert result["bnb_tps"] > result["eth_tps"]
+
+
+@pytest.mark.asyncio
+async def test_fee_revenue_block_positive():
+    result = await compute_on_chain_tx_velocity("LYNUSDT")
+    assert result["fee_revenue_block"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_avg_tx_value_positive():
+    result = await compute_on_chain_tx_velocity("LYNUSDT")
+    assert result["avg_tx_value"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_congestion_index_range():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    ci = result["congestion_index"]
+    assert 0.0 <= ci <= 100.0
+
+
+@pytest.mark.asyncio
+async def test_throughput_percentile_range():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    tp = result["throughput_percentile"]
+    assert 0.0 <= tp <= 100.0
+
+
+@pytest.mark.asyncio
+async def test_trend_valid_values():
+    result = await compute_on_chain_tx_velocity("COSUSDT")
+    assert result["trend"] in ("rising", "stable", "falling")
+
+
+@pytest.mark.asyncio
+async def test_tps_history_24h_is_list():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert isinstance(result["tps_history_24h"], list)
+
+
+@pytest.mark.asyncio
+async def test_tps_history_24h_has_24_entries():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert len(result["tps_history_24h"]) == 24
+
+
+@pytest.mark.asyncio
+async def test_tps_history_entries_have_chain_keys():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    for entry in result["tps_history_24h"]:
+        assert "eth" in entry
+        assert "sol" in entry
+        assert "bnb" in entry
+
+
+@pytest.mark.asyncio
+async def test_tps_history_values_positive():
+    result = await compute_on_chain_tx_velocity("DEXEUSDT")
+    for entry in result["tps_history_24h"]:
+        assert entry["eth"] > 0.0
+        assert entry["sol"] > 0.0
+        assert entry["bnb"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_deterministic_same_symbol():
+    r1 = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    r2 = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    assert r1["eth_tps"] == r2["eth_tps"]
+    assert r1["sol_tps"] == r2["sol_tps"]
+    assert r1["bnb_tps"] == r2["bnb_tps"]
+
+
+@pytest.mark.asyncio
+async def test_different_symbols_different_eth_tps():
+    r1 = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    r2 = await compute_on_chain_tx_velocity("COSUSDT")
+    # Different seeds → different values
+    assert r1["eth_tps"] != r2["eth_tps"]
+
+
+@pytest.mark.asyncio
+async def test_fee_revenue_is_float():
+    result = await compute_on_chain_tx_velocity("COSUSDT")
+    assert isinstance(result["fee_revenue_block"], float)
+
+
+@pytest.mark.asyncio
+async def test_avg_tx_value_is_float():
+    result = await compute_on_chain_tx_velocity("LYNUSDT")
+    assert isinstance(result["avg_tx_value"], float)
+
+
+@pytest.mark.asyncio
+async def test_congestion_index_is_float():
+    result = await compute_on_chain_tx_velocity("DEXEUSDT")
+    assert isinstance(result["congestion_index"], float)
+
+
+@pytest.mark.asyncio
+async def test_throughput_percentile_is_float():
+    result = await compute_on_chain_tx_velocity("DEXEUSDT")
+    assert isinstance(result["throughput_percentile"], float)
+
+
+@pytest.mark.asyncio
+async def test_all_symbols_work():
+    for sym in ("BANANAS31USDT", "COSUSDT", "DEXEUSDT", "LYNUSDT"):
+        result = await compute_on_chain_tx_velocity(sym)
+        assert result["eth_tps"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_tps_history_sol_greater_than_eth_per_entry():
+    result = await compute_on_chain_tx_velocity("BANANAS31USDT")
+    for entry in result["tps_history_24h"]:
+        assert entry["sol"] > entry["eth"]

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2499,6 +2499,8 @@ async function refresh() {
     // Batch 24: macro liquidity indicator
     // Batch 24: token velocity + NVT
     await Promise.all([safe(renderTokenVelocityNvt)]);
+    // Batch 27: on-chain tx velocity
+    await Promise.all([safe(renderOnChainTxVelocity)]);
     // Batch 16: derivatives heatmap
         // Batch 25: holder distribution card
         // Batch 26: cross-chain bridge monitor
@@ -2743,6 +2745,64 @@ async function renderTokenVelocityNvt() {
     </div>
     <div style="margin-top:4px">${sparkbars}</div>
     ${data.description ? `<div style="font-size:10px;color:var(--muted);margin-top:4px">${data.description}</div>` : ''}`;
+}
+
+// ── On-Chain TX Velocity ──────────────────────────────────────────────────────
+async function renderOnChainTxVelocity() {
+  const el    = document.getElementById('on-chain-tx-velocity-content');
+  const badge = document.getElementById('on-chain-tx-velocity-badge');
+  if (!el) return;
+  const sym  = window._currentSymbol || 'BANANAS31USDT';
+  const data = await apiFetch(`/on-chain-tx-velocity?symbol=${sym}`);
+  if (!data) { setErr('on-chain-tx-velocity-content'); return; }
+
+  const trend  = data.trend || 'stable';
+  const ci     = data.congestion_index ?? 0;
+  const tp     = data.throughput_percentile ?? 0;
+
+  const trendCol = trend === 'rising'  ? 'var(--green)'
+                 : trend === 'falling' ? 'var(--red)'
+                 : 'var(--muted)';
+  const ciCol    = ci > 70 ? 'var(--red)' : ci > 40 ? 'var(--yellow, #f59e0b)' : 'var(--green)';
+
+  if (badge) {
+    badge.textContent   = trend.toUpperCase();
+    badge.className     = `card-badge ${trend === 'rising' ? 'badge-green' : trend === 'falling' ? 'badge-red' : 'badge-blue'}`;
+    badge.style.display = '';
+  }
+
+  const hist = data.tps_history_24h || [];
+  const sparkbars = hist.map(h => {
+    const v   = h.eth ?? 0;
+    const pct = Math.min(v / 25 * 100, 100);
+    const col = v > 18 ? 'var(--red)' : v > 12 ? 'var(--yellow, #f59e0b)' : 'var(--green)';
+    return `<span style="display:inline-block;width:4px;height:${Math.max(pct * 0.12, 2).toFixed(0)}px;background:${col};margin-right:1px;vertical-align:bottom;opacity:0.8"></span>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);margin-bottom:6px">
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:3px">
+        <span style="font-size:9px;color:var(--muted);width:70px">Congestion</span>
+        <div style="flex:1;background:var(--border);height:8px;border-radius:3px">
+          <div style="width:${ci.toFixed(1)}%;background:${ciCol};height:100%;border-radius:3px"></div>
+        </div>
+        <b style="color:${ciCol};font-size:10px;min-width:36px;text-align:right">${ci.toFixed(1)}</b>
+      </div>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>ETH: <b style="color:var(--fg)">${(data.eth_tps??0).toFixed(1)} TPS</b></span>
+      <span>SOL: <b style="color:var(--fg)">${(data.sol_tps??0).toFixed(0)} TPS</b></span>
+      <span>BNB: <b style="color:var(--fg)">${(data.bnb_tps??0).toFixed(1)} TPS</b></span>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>Fee/block: <b style="color:var(--fg)">$${(data.fee_revenue_block??0).toFixed(2)}</b></span>
+      <span>Avg tx: <b style="color:var(--fg)">$${(data.avg_tx_value??0).toFixed(0)}</b></span>
+      <span>Pctile: <b style="color:var(--fg)">${tp.toFixed(1)}%</b></span>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px">
+      Trend: <b style="color:${trendCol}">${trend}</b>
+    </div>
+    <div style="margin-top:4px;line-height:1">${sparkbars}</div>`;
 }
 
 // ── Derivatives Heatmap ───────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -544,6 +544,18 @@
     </div>
   </section>
 
+  <!-- On-Chain TX Velocity -->
+  <section class="card" id="card-on-chain-tx-velocity">
+    <div class="card-header">
+      <span class="card-title">On-Chain TX Velocity</span>
+      <span id="on-chain-tx-velocity-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">ETH · SOL · BNB · TPS · fee revenue · congestion</span>
+    </div>
+    <div id="on-chain-tx-velocity-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- WebSocket Stats -->
   <section class="card" id="card-ws-stats">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- Adds `compute_on_chain_tx_velocity(symbol)` to `backend/metrics.py` with 7 pure helper functions (`_octv_tps`, `_octv_fee_revenue_per_block`, `_octv_avg_tx_value`, `_octv_congestion_index`, `_octv_throughput_percentile`, `_octv_trend`, `_octv_seed_for_symbol`)
- Adds `GET /api/on-chain-tx-velocity?symbol=` endpoint to `backend/api.py`
- Adds 75 tests in `backend/tests/test_on_chain_tx_velocity.py` — all passing
- Adds frontend card with congestion gauge, per-chain TPS (ETH/SOL/BNB), fee revenue, avg tx value, throughput percentile, trend, and 24h ETH TPS sparkbar

## Feature Details
- Seeded simulation (no external calls) — deterministic per symbol
- Returns: `eth_tps`, `sol_tps`, `bnb_tps`, `fee_revenue_block`, `avg_tx_value`, `congestion_index` (0–100), `throughput_percentile` (0–100), `trend` (rising/stable/falling), `tps_history_24h` (24 hourly entries)

## Test plan
- [x] `python3 -m pytest backend/tests/test_on_chain_tx_velocity.py -v` — 75 passed
- [ ] Verify card renders in dashboard at http://localhost:8765
- [ ] Check endpoint at http://localhost:8766/api/on-chain-tx-velocity

🤖 Generated with [Claude Code](https://claude.com/claude-code)