### PR TITLE
feat: cross-exchange funding rate arbitrage monitor

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -72,6 +72,7 @@ from metrics import (
     compute_layer2_metrics,
     compute_nft_market_pulse,
     compute_cross_chain_bridge_monitor,
+    compute_cross_exchange_funding_arb,
 )
 
 router = APIRouter(prefix="/api")
@@ -5326,4 +5327,13 @@ async def holder_distribution_endpoint():
 async def cross_chain_bridge_monitor_endpoint():
     """Cross-chain bridge monitor: flows across ETH/BSC/ARB/OP/BASE, top bridges, anomaly detection."""
     data = await compute_cross_chain_bridge_monitor()
+    return JSONResponse(data)
+
+
+@router.get("/cross-exchange-funding-arb")
+async def cross_exchange_funding_arb_endpoint(
+    symbol: Optional[str] = None,
+):
+    """Cross-exchange funding rate arb: Binance/Bybit/OKX/Bitget divergence, carry cost, arb signal."""
+    data = await compute_cross_exchange_funding_arb(symbol=symbol)
     return JSONResponse(data)

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -8537,3 +8537,133 @@ async def compute_cross_chain_bridge_monitor() -> dict:
         "zscore":           float(zscore),
         "description":      desc,
     }
+
+
+# ── Cross-Exchange Funding Rate Arbitrage ─────────────────────────────────────
+
+async def compute_cross_exchange_funding_arb(symbol: str = None) -> Dict:
+    """
+    Cross-exchange funding rate arbitrage monitor.
+
+    Compares simulated funding rates across Binance, Bybit, OKX, and Bitget.
+    Uses a seeded random walk (seed=99) — fully deterministic, no external API calls.
+
+    Returns
+    -------
+    binance_rate, bybit_rate, okx_rate, bitget_rate
+        Current 8-hour funding rates (decimal; 0.0001 == 0.01%).
+    max_divergence
+        Max spread between any two exchanges (decimal).
+    divergence_bps
+        max_divergence expressed in basis points (1 bp = 0.0001).
+    carry_cost_daily
+        Daily carry cost per $10 000 position in USD
+        (avg |rate| × 3 payments/day × $10 000).
+    arb_signal
+        "exploit" — divergence > mean + 1σ of 30-day history.
+        "watch"   — divergence > mean + 0.5σ.
+        "neutral" — otherwise.
+    percentile_rank
+        Where current divergence sits within the simulated 30-day history (0–100).
+    history_24h
+        288 dicts (5-min intervals) each with keys:
+        timestamp, binance, bybit, okx, bitget.
+    stddev_30d
+        Standard deviation of the divergence time series over 30 days.
+    description
+        Human-readable summary of the current signal.
+    """
+    import random as _rand
+    import math as _math
+
+    _rand.seed(99)
+
+    # Typical funding rate base: 0.01 % per 8 h = 0.0001
+    _BASE = 0.0001
+    _EXCHANGES = ("binance", "bybit", "okx", "bitget")
+
+    N_30D = 30 * 24 * 12   # 8 640 points at 5-min resolution
+    N_24H = 24 * 12         # 288 points
+
+    # Build 30-day random-walk history for each exchange
+    rates_30d: Dict[str, list] = {ex: [] for ex in _EXCHANGES}
+    for ex in _EXCHANGES:
+        rate = _BASE
+        for _ in range(N_30D):
+            rate += _rand.gauss(0, 0.000005)
+            rate = max(-0.001, min(0.001, rate))
+            rates_30d[ex].append(rate)
+
+    # Current rates = last simulated point
+    binance_rate = rates_30d["binance"][-1]
+    bybit_rate   = rates_30d["bybit"][-1]
+    okx_rate     = rates_30d["okx"][-1]
+    bitget_rate  = rates_30d["bitget"][-1]
+    current_rates = [binance_rate, bybit_rate, okx_rate, bitget_rate]
+
+    # Divergence series over 30 days
+    divergence_30d = [
+        max(rates_30d[ex][i] for ex in _EXCHANGES)
+        - min(rates_30d[ex][i] for ex in _EXCHANGES)
+        for i in range(N_30D)
+    ]
+
+    max_divergence = max(current_rates) - min(current_rates)
+    divergence_bps = round(max_divergence * 10000, 4)
+
+    # 30-day statistics
+    mean_div = sum(divergence_30d) / len(divergence_30d)
+    variance = sum((x - mean_div) ** 2 for x in divergence_30d) / len(divergence_30d)
+    stddev_30d = _math.sqrt(variance)
+
+    # Percentile rank: fraction of 30d history below current divergence
+    below = sum(1 for d in divergence_30d if d < max_divergence)
+    percentile_rank = round(below / len(divergence_30d) * 100, 1)
+
+    # Signal classification
+    if max_divergence > mean_div + stddev_30d:
+        arb_signal = "exploit"
+    elif max_divergence > mean_div + 0.5 * stddev_30d:
+        arb_signal = "watch"
+    else:
+        arb_signal = "neutral"
+
+    # Carry cost: 3 payments per day (8-hour intervals), per $10 000
+    avg_abs_rate = sum(abs(r) for r in current_rates) / len(current_rates)
+    carry_cost_daily = round(avg_abs_rate * 3 * 10_000, 4)
+
+    # 24-hour history slice (last 288 points of the 30-day simulation)
+    history_24h = []
+    for i in range(N_24H):
+        idx = N_30D - N_24H + i
+        history_24h.append({
+            "timestamp": f"t-{N_24H - i}",
+            "binance":   round(rates_30d["binance"][idx], 8),
+            "bybit":     round(rates_30d["bybit"][idx], 8),
+            "okx":       round(rates_30d["okx"][idx], 8),
+            "bitget":    round(rates_30d["bitget"][idx], 8),
+        })
+
+    highest_ex = _EXCHANGES[current_rates.index(max(current_rates))]
+    lowest_ex  = _EXCHANGES[current_rates.index(min(current_rates))]
+    description = (
+        f"{arb_signal.upper()}: {highest_ex.capitalize()} "
+        f"{max(current_rates) * 100:+.4f}% vs {lowest_ex.capitalize()} "
+        f"{min(current_rates) * 100:+.4f}% "
+        f"({divergence_bps:.2f} bps, p{percentile_rank:.0f})"
+    )
+
+    return {
+        "binance_rate":     round(binance_rate, 8),
+        "bybit_rate":       round(bybit_rate, 8),
+        "okx_rate":         round(okx_rate, 8),
+        "bitget_rate":      round(bitget_rate, 8),
+        "max_divergence":   round(max_divergence, 8),
+        "divergence_bps":   divergence_bps,
+        "carry_cost_daily": carry_cost_daily,
+        "arb_signal":       arb_signal,
+        "percentile_rank":  percentile_rank,
+        "stddev_30d":       round(stddev_30d, 8),
+        "history_24h":      history_24h,
+        "description":      description,
+    }

--- a/backend/tests/test_cross_exchange_funding_arb.py
+++ b/backend/tests/test_cross_exchange_funding_arb.py
@@ -1,0 +1,431 @@
+"""Tests for compute_cross_exchange_funding_arb — 50+ assertions, TDD-first."""
+import os
+import sys
+import tempfile
+import math
+import pytest
+
+os.environ.setdefault("DB_PATH", os.path.join(tempfile.mkdtemp(), "test_cxfa.db"))
+os.environ.setdefault("SYMBOL_BINANCE", "BANANAS31USDT")
+os.environ.setdefault("SYMBOL_BYBIT", "BANANAS31USDT")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from metrics import compute_cross_exchange_funding_arb  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def result(event_loop):
+    """Run the function once and share across tests."""
+    import asyncio
+    return event_loop.run_until_complete(compute_cross_exchange_funding_arb())
+
+
+@pytest.fixture(scope="module")
+def result_sym(event_loop):
+    """Run with explicit symbol."""
+    import asyncio
+    return event_loop.run_until_complete(
+        compute_cross_exchange_funding_arb(symbol="BANANAS31USDT")
+    )
+
+
+@pytest.fixture(scope="module")
+def result2(event_loop):
+    """Second call — used to verify determinism."""
+    import asyncio
+    return event_loop.run_until_complete(compute_cross_exchange_funding_arb())
+
+
+# ---------------------------------------------------------------------------
+# 1. Return type
+# ---------------------------------------------------------------------------
+
+def test_returns_dict(result):
+    assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# 2. Required keys present
+# ---------------------------------------------------------------------------
+
+def test_has_binance_rate(result):
+    assert "binance_rate" in result
+
+
+def test_has_bybit_rate(result):
+    assert "bybit_rate" in result
+
+
+def test_has_okx_rate(result):
+    assert "okx_rate" in result
+
+
+def test_has_bitget_rate(result):
+    assert "bitget_rate" in result
+
+
+def test_has_max_divergence(result):
+    assert "max_divergence" in result
+
+
+def test_has_divergence_bps(result):
+    assert "divergence_bps" in result
+
+
+def test_has_carry_cost_daily(result):
+    assert "carry_cost_daily" in result
+
+
+def test_has_arb_signal(result):
+    assert "arb_signal" in result
+
+
+def test_has_percentile_rank(result):
+    assert "percentile_rank" in result
+
+
+def test_has_history_24h(result):
+    assert "history_24h" in result
+
+
+def test_has_description(result):
+    assert "description" in result
+
+
+def test_has_stddev_30d(result):
+    assert "stddev_30d" in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Types
+# ---------------------------------------------------------------------------
+
+def test_binance_rate_is_float(result):
+    assert isinstance(result["binance_rate"], float)
+
+
+def test_bybit_rate_is_float(result):
+    assert isinstance(result["bybit_rate"], float)
+
+
+def test_okx_rate_is_float(result):
+    assert isinstance(result["okx_rate"], float)
+
+
+def test_bitget_rate_is_float(result):
+    assert isinstance(result["bitget_rate"], float)
+
+
+def test_max_divergence_is_float(result):
+    assert isinstance(result["max_divergence"], float)
+
+
+def test_divergence_bps_is_float(result):
+    assert isinstance(result["divergence_bps"], float)
+
+
+def test_carry_cost_daily_is_float(result):
+    assert isinstance(result["carry_cost_daily"], float)
+
+
+def test_arb_signal_is_string(result):
+    assert isinstance(result["arb_signal"], str)
+
+
+def test_percentile_rank_is_float(result):
+    assert isinstance(result["percentile_rank"], float)
+
+
+def test_history_24h_is_list(result):
+    assert isinstance(result["history_24h"], list)
+
+
+def test_description_is_string(result):
+    assert isinstance(result["description"], str)
+
+
+def test_stddev_30d_is_float(result):
+    assert isinstance(result["stddev_30d"], float)
+
+
+# ---------------------------------------------------------------------------
+# 4. Value ranges
+# ---------------------------------------------------------------------------
+
+def test_max_divergence_non_negative(result):
+    assert result["max_divergence"] >= 0.0
+
+
+def test_divergence_bps_non_negative(result):
+    assert result["divergence_bps"] >= 0.0
+
+
+def test_carry_cost_daily_non_negative(result):
+    assert result["carry_cost_daily"] >= 0.0
+
+
+def test_arb_signal_valid_values(result):
+    assert result["arb_signal"] in ("exploit", "watch", "neutral")
+
+
+def test_percentile_rank_lower_bound(result):
+    assert result["percentile_rank"] >= 0.0
+
+
+def test_percentile_rank_upper_bound(result):
+    assert result["percentile_rank"] <= 100.0
+
+
+def test_stddev_30d_positive(result):
+    assert result["stddev_30d"] >= 0.0
+
+
+def test_history_24h_non_empty(result):
+    assert len(result["history_24h"]) > 0
+
+
+def test_history_24h_length(result):
+    """24h at 5-min intervals = 288 points."""
+    assert len(result["history_24h"]) == 288
+
+
+def test_description_non_empty(result):
+    assert len(result["description"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Rate value range (funding rates are tiny, usually -0.1% to +0.1%)
+# ---------------------------------------------------------------------------
+
+def test_binance_rate_in_range(result):
+    assert -0.01 <= result["binance_rate"] <= 0.01
+
+
+def test_bybit_rate_in_range(result):
+    assert -0.01 <= result["bybit_rate"] <= 0.01
+
+
+def test_okx_rate_in_range(result):
+    assert -0.01 <= result["okx_rate"] <= 0.01
+
+
+def test_bitget_rate_in_range(result):
+    assert -0.01 <= result["bitget_rate"] <= 0.01
+
+
+def test_binance_rate_is_finite(result):
+    assert math.isfinite(result["binance_rate"])
+
+
+def test_bybit_rate_is_finite(result):
+    assert math.isfinite(result["bybit_rate"])
+
+
+def test_okx_rate_is_finite(result):
+    assert math.isfinite(result["okx_rate"])
+
+
+def test_bitget_rate_is_finite(result):
+    assert math.isfinite(result["bitget_rate"])
+
+
+# ---------------------------------------------------------------------------
+# 6. max_divergence correctness — must be >= every pairwise gap
+# ---------------------------------------------------------------------------
+
+def test_max_divergence_geq_binance_bybit(result):
+    diff = abs(result["binance_rate"] - result["bybit_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+def test_max_divergence_geq_binance_okx(result):
+    diff = abs(result["binance_rate"] - result["okx_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+def test_max_divergence_geq_binance_bitget(result):
+    diff = abs(result["binance_rate"] - result["bitget_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+def test_max_divergence_geq_bybit_okx(result):
+    diff = abs(result["bybit_rate"] - result["okx_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+def test_max_divergence_geq_bybit_bitget(result):
+    diff = abs(result["bybit_rate"] - result["bitget_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+def test_max_divergence_geq_okx_bitget(result):
+    diff = abs(result["okx_rate"] - result["bitget_rate"])
+    assert result["max_divergence"] >= diff - 1e-10
+
+
+# ---------------------------------------------------------------------------
+# 7. divergence_bps == max_divergence * 10000 (within rounding)
+# ---------------------------------------------------------------------------
+
+def test_divergence_bps_conversion(result):
+    expected = result["max_divergence"] * 10000
+    assert abs(result["divergence_bps"] - expected) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# 8. History structure
+# ---------------------------------------------------------------------------
+
+def test_history_first_has_timestamp(result):
+    assert "timestamp" in result["history_24h"][0]
+
+
+def test_history_first_has_binance(result):
+    assert "binance" in result["history_24h"][0]
+
+
+def test_history_first_has_bybit(result):
+    assert "bybit" in result["history_24h"][0]
+
+
+def test_history_first_has_okx(result):
+    assert "okx" in result["history_24h"][0]
+
+
+def test_history_first_has_bitget(result):
+    assert "bitget" in result["history_24h"][0]
+
+
+def test_history_last_has_timestamp(result):
+    assert "timestamp" in result["history_24h"][-1]
+
+
+def test_history_last_has_binance(result):
+    assert "binance" in result["history_24h"][-1]
+
+
+def test_history_last_has_bybit(result):
+    assert "bybit" in result["history_24h"][-1]
+
+
+def test_history_last_has_okx(result):
+    assert "okx" in result["history_24h"][-1]
+
+
+def test_history_last_has_bitget(result):
+    assert "bitget" in result["history_24h"][-1]
+
+
+def test_history_rates_are_floats(result):
+    h = result["history_24h"][0]
+    assert isinstance(h["binance"], float)
+    assert isinstance(h["bybit"], float)
+    assert isinstance(h["okx"], float)
+    assert isinstance(h["bitget"], float)
+
+
+def test_history_rates_in_valid_range(result):
+    for h in result["history_24h"]:
+        for ex in ("binance", "bybit", "okx", "bitget"):
+            assert -0.01 <= h[ex] <= 0.01, f"{ex} rate {h[ex]} out of range"
+
+
+# ---------------------------------------------------------------------------
+# 9. Determinism (same seed → same result)
+# ---------------------------------------------------------------------------
+
+def test_deterministic_binance_rate(result, result2):
+    assert result["binance_rate"] == result2["binance_rate"]
+
+
+def test_deterministic_bybit_rate(result, result2):
+    assert result["bybit_rate"] == result2["bybit_rate"]
+
+
+def test_deterministic_max_divergence(result, result2):
+    assert result["max_divergence"] == result2["max_divergence"]
+
+
+def test_deterministic_arb_signal(result, result2):
+    assert result["arb_signal"] == result2["arb_signal"]
+
+
+def test_deterministic_percentile_rank(result, result2):
+    assert result["percentile_rank"] == result2["percentile_rank"]
+
+
+def test_deterministic_history_length(result, result2):
+    assert len(result["history_24h"]) == len(result2["history_24h"])
+
+
+# ---------------------------------------------------------------------------
+# 10. Works with different symbol arguments
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_works_with_none_symbol():
+    res = await compute_cross_exchange_funding_arb(symbol=None)
+    assert isinstance(res, dict)
+    assert "arb_signal" in res
+
+
+@pytest.mark.asyncio
+async def test_works_with_bananas31():
+    res = await compute_cross_exchange_funding_arb(symbol="BANANAS31USDT")
+    assert isinstance(res, dict)
+    assert "binance_rate" in res
+
+
+@pytest.mark.asyncio
+async def test_works_with_cosusdt():
+    res = await compute_cross_exchange_funding_arb(symbol="COSUSDT")
+    assert isinstance(res, dict)
+    assert "max_divergence" in res
+
+
+@pytest.mark.asyncio
+async def test_works_with_dexeusdt():
+    res = await compute_cross_exchange_funding_arb(symbol="DEXEUSDT")
+    assert isinstance(res, dict)
+    assert "carry_cost_daily" in res
+
+
+# ---------------------------------------------------------------------------
+# 11. Description contains signal keyword
+# ---------------------------------------------------------------------------
+
+def test_description_contains_signal(result):
+    sig = result["arb_signal"].upper()
+    assert sig in result["description"].upper()
+
+
+# ---------------------------------------------------------------------------
+# 12. Carry cost proportional to rates (sanity: non-zero rates → non-zero cost)
+# ---------------------------------------------------------------------------
+
+def test_carry_cost_positive_when_rates_nonzero(result):
+    rates = [
+        result["binance_rate"], result["bybit_rate"],
+        result["okx_rate"], result["bitget_rate"],
+    ]
+    if any(abs(r) > 1e-10 for r in rates):
+        assert result["carry_cost_daily"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 13. Percentile rank is plausible (divergence history has variance)
+# ---------------------------------------------------------------------------
+
+def test_percentile_rank_not_always_zero(result):
+    """With random walk history the rank should not be stuck at 0."""
+    assert result["percentile_rank"] >= 0.0
+
+
+def test_percentile_rank_not_always_100(result):
+    """With random walk history the rank should not always be at 100."""
+    assert result["percentile_rank"] <= 100.0

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2502,6 +2502,8 @@ async function refresh() {
     // Batch 16: derivatives heatmap
         // Batch 25: holder distribution card
         // Batch 26: cross-chain bridge monitor
+    // Batch 27: cross-exchange funding arb
+    await Promise.all([safe(renderCrossExchangeFundingArb)]);
   } finally {
     _refreshRunning = false;
   }
@@ -2747,6 +2749,84 @@ async function renderTokenVelocityNvt() {
 
 // ── Derivatives Heatmap ───────────────────────────────────────────────────────
 // ── Holder Distribution ───────────────────────────────────────────────────
+// ── Cross-Exchange Funding Arb ────────────────────────────────────────────────
+async function renderCrossExchangeFundingArb() {
+  const sym  = encodeURIComponent(activeSymbol);
+  const data = await apiFetch(`/cross-exchange-funding-arb?symbol=${sym}`);
+  const el   = document.getElementById('cross-exchange-funding-arb-content');
+  const badge = document.getElementById('cross-exchange-funding-arb-badge');
+  if (!el) return;
+  if (!data) { setErr('cross-exchange-funding-arb-content'); return; }
+
+  const signal = data.arb_signal ?? 'neutral';
+  const sigCol = signal === 'exploit' ? 'var(--red)'
+               : signal === 'watch'   ? '#f59e0b'
+               : 'var(--muted)';
+  const sigIcon = signal === 'exploit' ? '⚡' : signal === 'watch' ? '👀' : '—';
+
+  if (badge) {
+    badge.textContent = `${sigIcon} ${signal.toUpperCase()}`;
+    badge.className = `card-badge ${signal === 'exploit' ? 'badge-red' : signal === 'watch' ? 'badge-yellow' : 'badge-blue'}`;
+    badge.style.display = '';
+  }
+
+  const fmtRate = r => {
+    const pct = (r ?? 0) * 100;
+    const col = pct > 0.005 ? 'var(--red)' : pct < -0.005 ? 'var(--green)' : 'var(--muted)';
+    return `<b style="color:${col}">${pct >= 0 ? '+' : ''}${pct.toFixed(4)}%</b>`;
+  };
+
+  const divBps = data.divergence_bps ?? 0;
+  const pctRank = data.percentile_rank ?? 0;
+  const carry = data.carry_cost_daily ?? 0;
+  const stddev = (data.stddev_30d ?? 0) * 10000;
+
+  // Divergence gauge (0–10 bps range typical)
+  const gaugeMax = Math.max(divBps * 2, 2);
+  const gaugePct = Math.min(divBps / gaugeMax * 100, 100).toFixed(1);
+
+  // 24h sparkline of divergence between binance and bybit
+  const hist = (data.history_24h || []).slice(-48);
+  let sparkline = '';
+  if (hist.length >= 2) {
+    const divVals = hist.map(h => Math.abs((h.binance ?? 0) - (h.bybit ?? 0)) * 10000);
+    const dMax = Math.max(...divVals, 0.001);
+    const W = 140, H = 22;
+    const pts = divVals.map((v, i) => {
+      const x = (i / (divVals.length - 1)) * W;
+      const y = H - (v / dMax) * H;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+    sparkline = `<div style="font-size:9px;color:var(--muted);margin-bottom:2px">BIN–BYB div (4h)</div>
+    <svg width="${W}" height="${H}" style="display:block;margin-bottom:4px">
+      <polyline points="${pts}" fill="none" stroke="${sigCol}" stroke-width="1.5" opacity="0.8"/>
+    </svg>`;
+  }
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);display:flex;flex-wrap:wrap;gap:4px 10px;margin-bottom:4px">
+      <span>BIN: ${fmtRate(data.binance_rate)}</span>
+      <span>BYB: ${fmtRate(data.bybit_rate)}</span>
+      <span>OKX: ${fmtRate(data.okx_rate)}</span>
+      <span>BGT: ${fmtRate(data.bitget_rate)}</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
+      <span style="font-size:9px;color:var(--muted);width:32px">div</span>
+      <div style="flex:1;height:5px;background:var(--border);border-radius:3px">
+        <div style="width:${gaugePct}%;height:100%;background:${sigCol};border-radius:3px"></div>
+      </div>
+      <span style="font-size:9px;color:${sigCol};min-width:50px;text-align:right">${divBps.toFixed(2)} bps</span>
+    </div>
+    <div style="font-size:10px;color:var(--muted);display:flex;flex-wrap:wrap;gap:4px 10px;margin-bottom:4px">
+      <span>carry/day: <b style="color:var(--fg)">$${carry.toFixed(3)}</b>/10k</span>
+      <span>p-rank: <b style="color:var(--fg)">${pctRank.toFixed(0)}p</b></span>
+      <span>σ: <b style="color:var(--fg)">${stddev.toFixed(2)} bps</b></span>
+    </div>
+    ${sparkline}
+    ${data.description ? `<div style="font-size:10px;color:var(--muted)">${data.description}</div>` : ''}`;
+}
+
+
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 async function init() {
   const safeInit = (fn) => { try { fn(); } catch(e) { console.warn('Chart init failed:', e.message); } };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -544,6 +544,18 @@
     </div>
   </section>
 
+  <!-- Cross-Exchange Funding Arb -->
+  <section class="card" id="card-cross-exchange-funding-arb">
+    <div class="card-header">
+      <span class="card-title">Cross-Exchange Funding Arb</span>
+      <span id="cross-exchange-funding-arb-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">Binance · Bybit · OKX · Bitget · divergence · carry cost</span>
+    </div>
+    <div id="cross-exchange-funding-arb-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- WebSocket Stats -->
   <section class="card" id="card-ws-stats">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- `compute_cross_exchange_funding_arb(symbol)` in `backend/metrics.py`: seeded random-walk simulation (seed=99) across Binance/Bybit/OKX/Bitget with 30d history, divergence in bps, daily carry cost per \$10k, `arb_signal` (exploit/watch/neutral), and percentile rank
- `GET /api/cross-exchange-funding-arb` endpoint in `backend/api.py`
- Frontend card in `frontend/index.html` + `renderCrossExchangeFundingArb()` in `frontend/app.js` (per-exchange rates, divergence gauge, 4h sparkline)
- 76 passing tests in `backend/tests/test_cross_exchange_funding_arb.py` covering type, keys, ranges, pairwise divergence bounds, determinism, and symbol variants

## Test plan
- [x] `pytest backend/tests/test_cross_exchange_funding_arb.py` — 76/76 passed
- [x] No external API calls — fully seeded simulation
- [x] Deterministic output (same seed → same result across calls)
- [x] arb_signal in {exploit, watch, neutral}, percentile_rank in [0,100]
- [x] max_divergence >= every pairwise exchange gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)