### PR TITLE
feat: funding rate arbitrage scanner (68 tests)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -5520,6 +5520,21 @@ async def gamma_exposure_endpoint(symbol: Optional[str] = None):
     return JSONResponse(data)
 
 
+@router.get("/funding-arb-scanner")
+@cache_result(ttl_seconds=60)
+async def funding_arb_scanner_endpoint():
+    """
+    Funding Rate Arbitrage Scanner: scan funding rates across Binance/Bybit/OKX (simulated).
+
+    Finds the best cash-and-carry arb pairs by cross-exchange funding rate spread.
+    Returns top 3 pairs with estimated APR, extreme imbalance flags, and avg spread.
+    Data is seeded-mock (deterministic, no live API). Cache TTL: 60s.
+    """
+    from funding_arb_scanner import compute_funding_arb_scanner
+    data = compute_funding_arb_scanner()
+    return JSONResponse(data)
+
+
 @router.get("/whale-flow")
 @cache_result(ttl_seconds=60)
 async def whale_flow_endpoint(symbol: Optional[str] = None):

--- a/backend/funding_arb_scanner.py
+++ b/backend/funding_arb_scanner.py
@@ -1,0 +1,197 @@
+"""
+Funding Rate Arbitrage Scanner — Wave 23 Task 5 (Issue #119).
+
+Simulates funding rates across three exchanges (Binance, Bybit, OKX) and finds
+the best cash-and-carry arbitrage opportunities:
+  - Scan all symbols for cross-exchange funding rate spreads
+  - Long where funding rate is lowest (pay least / receive most when long)
+  - Short where funding rate is highest (receive most when short)
+  - Spread = short_rate - long_rate (both in %)
+  - APR = spread_pct * FUNDING_INTERVALS_PER_DAY * 365
+  - Flag extreme imbalances (spread > EXTREME_MULTIPLIER × avg_spread)
+  - Return top 3 pairs by spread
+
+Data source: seeded mock — deterministic per (symbol, exchange), no live API.
+"""
+
+import random
+import time
+from typing import Dict, List, Optional
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+EXCHANGES = ("binance", "bybit", "okx")
+
+SYMBOLS = (
+    "BTCUSDT",
+    "ETHUSDT",
+    "SOLUSDT",
+    "BNBUSDT",
+    "XRPUSDT",
+    "AVAXUSDT",
+)
+
+# Funding rate distribution (realistic: most rates near 0.01% per 8h interval)
+RATE_MEAN = 0.01  # 0.01% mean (slight contango typical in bull markets)
+RATE_STD = 0.04  # 0.04% standard deviation
+
+# Hard bounds: exchanges enforce ±0.15% max funding per interval
+RATE_MIN = -0.15
+RATE_MAX = 0.15
+
+# Funding is paid every 8 hours → 3 intervals per day
+FUNDING_INTERVALS_PER_DAY = 3
+DAYS_PER_YEAR = 365
+
+# Pair marked extreme when spread > EXTREME_MULTIPLIER × average spread
+EXTREME_MULTIPLIER = 2.0
+
+# Number of top pairs to include in summary
+TOP_N = 3
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _symbol_exchange_seed(symbol: str, exchange: str) -> int:
+    """Deterministic seed derived from (symbol, exchange) pair."""
+    combined = symbol + "|" + exchange
+    return sum(ord(c) * (i + 1) for i, c in enumerate(combined)) + 137
+
+
+# ── Core Functions ─────────────────────────────────────────────────────────────
+
+
+def scan_funding_rates(symbols: Optional[List[str]] = None) -> List[Dict]:
+    """
+    Simulate current funding rates for all (symbol, exchange) combinations.
+
+    Returns list of dicts:
+        symbol   (str):   trading pair
+        exchange (str):   exchange name
+        rate_pct (float): funding rate per 8h interval, in percent
+    """
+    syms: List[str] = list(symbols) if symbols is not None else list(SYMBOLS)
+    results: List[Dict] = []
+
+    for symbol in syms:
+        for exchange in EXCHANGES:
+            seed = _symbol_exchange_seed(symbol, exchange)
+            rng = random.Random(seed)
+            rate = rng.gauss(RATE_MEAN, RATE_STD)
+            rate = max(RATE_MIN, min(RATE_MAX, rate))
+            results.append(
+                {
+                    "symbol": symbol,
+                    "exchange": exchange,
+                    "rate_pct": round(rate, 6),
+                }
+            )
+
+    return results
+
+
+def compute_arb_pairs(rates: List[Dict]) -> List[Dict]:
+    """
+    Identify best cash-and-carry pair per symbol.
+
+    Strategy:
+        - Long the exchange with the lowest funding rate (pay least or receive most)
+        - Short the exchange with the highest funding rate (receive most)
+        - Spread = short_rate_pct - long_rate_pct
+        - spread_bps = spread_pct * 100
+        - estimated_apr_pct = spread_pct * FUNDING_INTERVALS_PER_DAY * DAYS_PER_YEAR
+
+    Returns list sorted by spread_bps descending.
+    """
+    # Group by symbol
+    by_symbol: Dict[str, List[Dict]] = {}
+    for r in rates:
+        by_symbol.setdefault(r["symbol"], []).append(r)
+
+    pairs: List[Dict] = []
+
+    for symbol, exchange_rates in by_symbol.items():
+        if len(exchange_rates) < 2:
+            continue
+
+        sorted_rates = sorted(exchange_rates, key=lambda x: x["rate_pct"])
+        long_ex = sorted_rates[0]  # lowest rate → go long here
+        short_ex = sorted_rates[-1]  # highest rate → go short here
+
+        long_rate = long_ex["rate_pct"]
+        short_rate = short_ex["rate_pct"]
+
+        spread_pct = short_rate - long_rate
+        spread_bps = round(spread_pct * 100, 2)
+        estimated_apr_pct = round(
+            spread_pct * FUNDING_INTERVALS_PER_DAY * DAYS_PER_YEAR, 2
+        )
+
+        pairs.append(
+            {
+                "symbol": symbol,
+                "long_exchange": long_ex["exchange"],
+                "short_exchange": short_ex["exchange"],
+                "long_rate_pct": round(long_rate, 6),
+                "short_rate_pct": round(short_rate, 6),
+                "spread_bps": spread_bps,
+                "estimated_apr_pct": estimated_apr_pct,
+                "is_extreme": False,  # filled by flag_extreme_pairs
+            }
+        )
+
+    return sorted(pairs, key=lambda x: x["spread_bps"], reverse=True)
+
+
+def flag_extreme_pairs(pairs: List[Dict]) -> List[Dict]:
+    """
+    Mark pairs where spread_bps > EXTREME_MULTIPLIER × avg_spread_bps as extreme.
+
+    Mutates pairs in-place; returns the same list.
+    """
+    if not pairs:
+        return pairs
+
+    avg_spread = sum(p["spread_bps"] for p in pairs) / len(pairs)
+    threshold = avg_spread * EXTREME_MULTIPLIER
+
+    for pair in pairs:
+        pair["is_extreme"] = pair["spread_bps"] > threshold
+
+    return pairs
+
+
+def compute_funding_arb_scanner(symbols: Optional[List[str]] = None) -> Dict:
+    """
+    Main entry point: scan funding rates and return arbitrage opportunities.
+
+    Returns:
+        top_pairs (list[dict]):  top TOP_N arb pairs by spread_bps
+        all_pairs (list[dict]):  all symbol pairs sorted by spread_bps descending
+        avg_spread_bps (float):  mean spread across all symbols
+        extreme_count (int):     number of extreme imbalance pairs
+        timestamp (float):       unix epoch seconds
+    """
+    rates = scan_funding_rates(symbols)
+    pairs = compute_arb_pairs(rates)
+    pairs = flag_extreme_pairs(pairs)
+
+    avg_spread_bps = (
+        round(sum(p["spread_bps"] for p in pairs) / len(pairs), 2) if pairs else 0.0
+    )
+    extreme_count = sum(1 for p in pairs if p["is_extreme"])
+
+    # Assign sequential ranks (1 = best)
+    for i, pair in enumerate(pairs):
+        pair["rank"] = i + 1
+
+    top_pairs = [dict(p) for p in pairs[:TOP_N]]
+
+    return {
+        "top_pairs": top_pairs,
+        "all_pairs": pairs,
+        "avg_spread_bps": avg_spread_bps,
+        "extreme_count": extreme_count,
+        "timestamp": time.time(),
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2559,6 +2559,8 @@ async function refresh() {
     await Promise.all([safe(renderWhaleFlow)]);
     // Batch 33: options gamma exposure (Wave 23)
     await Promise.all([safe(renderGammaExposure)]);
+    // Batch 34: funding rate arbitrage scanner (Wave 23)
+    await Promise.all([safe(renderFundingArbScanner)]);
   } finally {
     _refreshRunning = false;
   }
@@ -4115,6 +4117,75 @@ async function renderGammaExposure() {
     }
   } catch (err) {
     console.error('Error rendering gamma exposure:', err);
+    if (el) el.innerHTML = 'Error';
+  }
+}
+
+
+// ── Funding Rate Arbitrage Scanner (Wave 23, Issue #119) ──────────────────────
+async function renderFundingArbScanner() {
+  const el    = document.getElementById('funding-arb-scanner-content');
+  const badge = document.getElementById('funding-arb-scanner-badge');
+  if (!el) return;
+
+  try {
+    const res = await fetch('/api/funding-arb-scanner');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+
+    const { top_pairs, avg_spread_bps, extreme_count } = data;
+
+    const aprColor = (apr) =>
+      apr >= 50 ? '#27ae60' :
+      apr >= 20 ? '#f39c12' :
+      '#4a9eff';
+
+    const extremeTag = (pair) =>
+      pair.is_extreme
+        ? `<span style="color:#e74c3c;font-size:9px;margin-left:4px;">⚠ EXTREME</span>`
+        : '';
+
+    const fmtExchange = (ex) => ex.charAt(0).toUpperCase() + ex.slice(1);
+
+    const pairRows = top_pairs.map((pair) => `
+      <div style="display:grid;grid-template-columns:auto 1fr auto auto;align-items:center;gap:6px;padding:3px 0;border-bottom:1px solid #222;font-size:10px;">
+        <div style="color:#555;font-size:9px;">#${pair.rank}</div>
+        <div>
+          <span style="color:#e0e0e0;font-weight:bold;">${pair.symbol}</span>
+          ${extremeTag(pair)}
+          <div style="color:#666;font-size:9px;">${fmtExchange(pair.long_exchange)} long / ${fmtExchange(pair.short_exchange)} short</div>
+        </div>
+        <div style="text-align:right;">
+          <div style="color:#4a9eff;font-weight:bold;">${pair.spread_bps.toFixed(1)} bps</div>
+          <div style="color:#555;font-size:9px;">spread</div>
+        </div>
+        <div style="text-align:right;">
+          <div style="color:${aprColor(pair.estimated_apr_pct)};font-weight:bold;">${pair.estimated_apr_pct.toFixed(1)}%</div>
+          <div style="color:#555;font-size:9px;">APR</div>
+        </div>
+      </div>
+    `).join('');
+
+    el.innerHTML = `
+      ${pairRows}
+      <div style="display:flex;justify-content:space-between;font-size:9px;color:#666;margin-top:4px;">
+        <span>Avg spread: <span style="color:#aaa;">${avg_spread_bps.toFixed(1)} bps</span></span>
+        <span>Extreme: <span style="color:${extreme_count > 0 ? '#e74c3c' : '#555'};">${extreme_count}</span></span>
+      </div>
+    `;
+
+    if (badge) {
+      const topApr = top_pairs.length > 0 ? top_pairs[0].estimated_apr_pct : 0;
+      badge.textContent = `${topApr.toFixed(0)}% APR`;
+      badge.style.background = aprColor(topApr);
+      badge.style.color = '#fff';
+      badge.style.fontSize = '10px';
+      badge.style.padding = '2px 6px';
+      badge.style.display = 'inline-block';
+      badge.style.borderRadius = '3px';
+    }
+  } catch (err) {
+    console.error('Error rendering funding arb scanner:', err);
     if (el) el.innerHTML = 'Error';
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -709,6 +709,16 @@
     <div id="market-regime-content" style="font-size:11px;">Loading…</div>
   </section>
 
+  <!-- Funding Rate Arbitrage Scanner Card -->
+  <section class="card" id="card-funding-arb-scanner">
+    <div class="card-header">
+      <span class="card-title">Funding Arb Scanner</span>
+      <span id="funding-arb-scanner-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">top 3 arb pairs · spread bps · estimated APR · extreme flags</span>
+    </div>
+    <div id="funding-arb-scanner-content" style="font-size:11px;">Loading…</div>
+  </section>
+
 </main>
 
 <script src="app.js?v=100"></script>

--- a/tests/test_funding_arb_scanner.py
+++ b/tests/test_funding_arb_scanner.py
@@ -1,0 +1,379 @@
+"""
+Tests for Funding Rate Arbitrage Scanner (Wave 23 Task 5, Issue #119).
+
+TDD: tests written before implementation.
+Covers:
+  - scan_funding_rates: 6 symbols × 3 exchanges = 18 entries
+  - compute_arb_pairs: one arb pair per symbol, sorted by spread_bps
+  - flag_extreme_pairs: is_extreme flag logic
+  - compute_funding_arb_scanner: top 3 pairs, avg_spread_bps, extreme_count
+  - APR calculation: spread_pct * 3 * 365
+  - Determinism: seeded mock gives same results every call
+  - Performance: < 200ms
+  - Frontend HTML: card-funding-arb-scanner, badge, content div
+  - Frontend JS: renderFundingArbScanner, API call, signal colors
+"""
+
+import math
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from funding_arb_scanner import (
+    EXCHANGES,
+    EXTREME_MULTIPLIER,
+    FUNDING_INTERVALS_PER_DAY,
+    SYMBOLS,
+    TOP_N,
+    compute_arb_pairs,
+    compute_funding_arb_scanner,
+    flag_extreme_pairs,
+    scan_funding_rates,
+)
+
+FRONTEND_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def html_content():
+    with open(os.path.join(FRONTEND_DIR, "index.html")) as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
+def js_content():
+    with open(os.path.join(FRONTEND_DIR, "app.js")) as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
+def scanner_result():
+    return compute_funding_arb_scanner()
+
+
+@pytest.fixture(scope="module")
+def rates():
+    return scan_funding_rates()
+
+
+@pytest.fixture(scope="module")
+def all_pairs(rates):
+    pairs = compute_arb_pairs(rates)
+    return flag_extreme_pairs(pairs)
+
+
+# ── Category 1: Return Shape ──────────────────────────────────────────────────
+
+
+class TestReturnShape:
+    def test_returns_dict(self, scanner_result):
+        assert isinstance(scanner_result, dict)
+
+    def test_has_top_pairs(self, scanner_result):
+        assert "top_pairs" in scanner_result
+
+    def test_has_all_pairs(self, scanner_result):
+        assert "all_pairs" in scanner_result
+
+    def test_has_avg_spread_bps(self, scanner_result):
+        assert "avg_spread_bps" in scanner_result
+
+    def test_has_extreme_count(self, scanner_result):
+        assert "extreme_count" in scanner_result
+
+    def test_has_timestamp(self, scanner_result):
+        assert "timestamp" in scanner_result
+
+    def test_timestamp_is_numeric(self, scanner_result):
+        assert isinstance(scanner_result["timestamp"], (int, float))
+
+    def test_avg_spread_bps_is_numeric(self, scanner_result):
+        assert isinstance(scanner_result["avg_spread_bps"], (int, float))
+
+    def test_extreme_count_is_non_negative_int(self, scanner_result):
+        ec = scanner_result["extreme_count"]
+        assert isinstance(ec, int)
+        assert ec >= 0
+
+    def test_top_pairs_is_list(self, scanner_result):
+        assert isinstance(scanner_result["top_pairs"], list)
+
+    def test_all_pairs_is_list(self, scanner_result):
+        assert isinstance(scanner_result["all_pairs"], list)
+
+
+# ── Category 2: Top Pairs Shape ───────────────────────────────────────────────
+
+
+class TestTopPairsShape:
+    def test_top_pairs_at_most_3(self, scanner_result):
+        assert len(scanner_result["top_pairs"]) <= TOP_N
+
+    def test_top_pairs_exactly_3_with_default_symbols(self, scanner_result):
+        # 6 default symbols → 6 arb pairs → top 3 returned
+        assert len(scanner_result["top_pairs"]) == TOP_N
+
+    def test_top_pairs_sorted_by_spread_bps_descending(self, scanner_result):
+        spreads = [p["spread_bps"] for p in scanner_result["top_pairs"]]
+        assert spreads == sorted(spreads, reverse=True)
+
+    def test_top_pairs_have_symbol(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "symbol" in pair
+
+    def test_top_pairs_have_long_exchange(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "long_exchange" in pair
+
+    def test_top_pairs_have_short_exchange(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "short_exchange" in pair
+
+    def test_top_pairs_have_long_rate_pct(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "long_rate_pct" in pair
+
+    def test_top_pairs_have_short_rate_pct(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "short_rate_pct" in pair
+
+    def test_top_pairs_have_spread_bps(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "spread_bps" in pair
+
+    def test_top_pairs_have_estimated_apr_pct(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "estimated_apr_pct" in pair
+
+    def test_top_pairs_have_is_extreme(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "is_extreme" in pair
+
+    def test_top_pairs_have_rank(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert "rank" in pair
+
+    def test_top_pair_rank_starts_at_1(self, scanner_result):
+        assert scanner_result["top_pairs"][0]["rank"] == 1
+
+    def test_top_pair_ranks_are_sequential(self, scanner_result):
+        ranks = [p["rank"] for p in scanner_result["top_pairs"]]
+        assert ranks == list(range(1, len(ranks) + 1))
+
+    def test_exchanges_differ_per_pair(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert pair["long_exchange"] != pair["short_exchange"]
+
+    def test_spread_bps_non_negative(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert pair["spread_bps"] >= 0
+
+    def test_estimated_apr_non_negative(self, scanner_result):
+        for pair in scanner_result["top_pairs"]:
+            assert pair["estimated_apr_pct"] >= 0
+
+    def test_top_pair_has_highest_spread(self, scanner_result):
+        top_spread = scanner_result["top_pairs"][0]["spread_bps"]
+        for pair in scanner_result["all_pairs"]:
+            assert top_spread >= pair["spread_bps"]
+
+
+# ── Category 3: All Pairs ─────────────────────────────────────────────────────
+
+
+class TestAllPairs:
+    def test_all_pairs_count_equals_symbol_count(self, scanner_result):
+        assert len(scanner_result["all_pairs"]) == len(SYMBOLS)
+
+    def test_all_pairs_sorted_by_spread_bps_descending(self, scanner_result):
+        spreads = [p["spread_bps"] for p in scanner_result["all_pairs"]]
+        assert spreads == sorted(spreads, reverse=True)
+
+    def test_all_pairs_symbols_are_valid(self, scanner_result):
+        for pair in scanner_result["all_pairs"]:
+            assert pair["symbol"] in SYMBOLS
+
+    def test_all_pairs_cover_all_symbols(self, scanner_result):
+        result_symbols = {p["symbol"] for p in scanner_result["all_pairs"]}
+        assert result_symbols == set(SYMBOLS)
+
+    def test_extreme_count_matches_is_extreme_flags(self, scanner_result):
+        count = sum(1 for p in scanner_result["all_pairs"] if p["is_extreme"])
+        assert scanner_result["extreme_count"] == count
+
+
+# ── Category 4: Computation Tests ─────────────────────────────────────────────
+
+
+class TestScanFundingRates:
+    def test_scan_returns_correct_count(self, rates):
+        expected = len(SYMBOLS) * len(EXCHANGES)
+        assert len(rates) == expected
+
+    def test_each_rate_has_symbol(self, rates):
+        for r in rates:
+            assert "symbol" in r
+
+    def test_each_rate_has_exchange(self, rates):
+        for r in rates:
+            assert "exchange" in r
+
+    def test_each_rate_has_rate_pct(self, rates):
+        for r in rates:
+            assert "rate_pct" in r
+
+    def test_rate_pct_in_valid_range(self, rates):
+        for r in rates:
+            assert -0.15 <= r["rate_pct"] <= 0.15
+
+    def test_exchanges_include_binance(self, rates):
+        exchanges = {r["exchange"] for r in rates}
+        assert "binance" in exchanges
+
+    def test_exchanges_include_bybit(self, rates):
+        exchanges = {r["exchange"] for r in rates}
+        assert "bybit" in exchanges
+
+    def test_exchanges_include_okx(self, rates):
+        exchanges = {r["exchange"] for r in rates}
+        assert "okx" in exchanges
+
+
+class TestComputeArbPairs:
+    def test_arb_pairs_one_per_symbol(self, rates):
+        pairs = compute_arb_pairs(rates)
+        assert len(pairs) == len(SYMBOLS)
+
+    def test_long_rate_lte_short_rate(self, rates):
+        pairs = compute_arb_pairs(rates)
+        for pair in pairs:
+            assert pair["long_rate_pct"] <= pair["short_rate_pct"]
+
+    def test_spread_bps_matches_formula(self, rates):
+        pairs = compute_arb_pairs(rates)
+        for pair in pairs:
+            expected = (pair["short_rate_pct"] - pair["long_rate_pct"]) * 100
+            assert abs(pair["spread_bps"] - expected) < 0.01
+
+    def test_apr_matches_formula(self, rates):
+        pairs = compute_arb_pairs(rates)
+        for pair in pairs:
+            spread_pct = pair["short_rate_pct"] - pair["long_rate_pct"]
+            expected_apr = spread_pct * FUNDING_INTERVALS_PER_DAY * 365
+            assert abs(pair["estimated_apr_pct"] - expected_apr) < 0.1
+
+    def test_pairs_sorted_by_spread_descending(self, rates):
+        pairs = compute_arb_pairs(rates)
+        spreads = [p["spread_bps"] for p in pairs]
+        assert spreads == sorted(spreads, reverse=True)
+
+
+class TestDeterminism:
+    def test_same_results_on_repeated_calls(self):
+        r1 = compute_funding_arb_scanner()
+        r2 = compute_funding_arb_scanner()
+        assert r1["top_pairs"][0]["symbol"] == r2["top_pairs"][0]["symbol"]
+        assert r1["top_pairs"][0]["spread_bps"] == r2["top_pairs"][0]["spread_bps"]
+        assert r1["avg_spread_bps"] == r2["avg_spread_bps"]
+        assert r1["extreme_count"] == r2["extreme_count"]
+
+    def test_rates_differ_across_exchanges_same_symbol(self, rates):
+        btc_rates = [r["rate_pct"] for r in rates if r["symbol"] == "BTCUSDT"]
+        assert len(set(btc_rates)) > 1
+
+    def test_rates_differ_across_symbols_same_exchange(self, rates):
+        binance_rates = [r["rate_pct"] for r in rates if r["exchange"] == "binance"]
+        assert len(set(binance_rates)) > 1
+
+
+# ── Category 5: Extreme Flags ─────────────────────────────────────────────────
+
+
+class TestExtremeFlags:
+    def test_extreme_pairs_have_high_spread(self, scanner_result):
+        avg = scanner_result["avg_spread_bps"]
+        threshold = avg * EXTREME_MULTIPLIER
+        for pair in scanner_result["all_pairs"]:
+            if pair["is_extreme"]:
+                assert pair["spread_bps"] > threshold
+
+    def test_non_extreme_pairs_have_low_spread(self, scanner_result):
+        avg = scanner_result["avg_spread_bps"]
+        threshold = avg * EXTREME_MULTIPLIER
+        for pair in scanner_result["all_pairs"]:
+            if not pair["is_extreme"]:
+                assert pair["spread_bps"] <= threshold
+
+    def test_is_extreme_is_bool(self, scanner_result):
+        for pair in scanner_result["all_pairs"]:
+            assert isinstance(pair["is_extreme"], bool)
+
+
+# ── Category 6: Performance ────────────────────────────────────────────────────
+
+
+class TestPerformance:
+    def test_response_under_200ms(self):
+        t0 = time.time()
+        compute_funding_arb_scanner()
+        elapsed_ms = (time.time() - t0) * 1000
+        assert elapsed_ms < 200, f"Took {elapsed_ms:.0f}ms, expected <200ms"
+
+
+# ── Category 7: Frontend HTML ─────────────────────────────────────────────────
+
+
+class TestFrontendHtml:
+    def test_card_id_exists(self, html_content):
+        assert "card-funding-arb-scanner" in html_content
+
+    def test_card_has_content_div(self, html_content):
+        assert "funding-arb-scanner-content" in html_content
+
+    def test_card_has_badge_span(self, html_content):
+        assert "funding-arb-scanner-badge" in html_content
+
+    def test_card_has_title(self, html_content):
+        assert "Funding Arb" in html_content or "Funding Rate Arb" in html_content
+
+    def test_card_has_meta_description(self, html_content):
+        assert "arb" in html_content.lower() or "APR" in html_content
+
+
+# ── Category 8: Frontend JS ───────────────────────────────────────────────────
+
+
+class TestFrontendJs:
+    def test_render_function_exists(self, js_content):
+        assert "renderFundingArbScanner" in js_content
+
+    def test_api_endpoint_wired(self, js_content):
+        assert "/api/funding-arb-scanner" in js_content
+
+    def test_badge_id_referenced(self, js_content):
+        assert "funding-arb-scanner-badge" in js_content
+
+    def test_top_pairs_referenced(self, js_content):
+        assert "top_pairs" in js_content
+
+    def test_estimated_apr_referenced(self, js_content):
+        assert "estimated_apr_pct" in js_content
+
+    def test_spread_bps_referenced(self, js_content):
+        assert "spread_bps" in js_content
+
+    def test_render_in_refresh_loop(self, js_content):
+        assert "safe(renderFundingArbScanner)" in js_content
+
+    def test_is_extreme_referenced(self, js_content):
+        assert "is_extreme" in js_content
+
+    def test_content_div_referenced(self, js_content):
+        assert "funding-arb-scanner-content" in js_content


### PR DESCRIPTION
## Summary

- New `backend/funding_arb_scanner.py`: seeded-mock funding rates across Binance/Bybit/OKX, cash-and-carry arb pair computation (spread bps + APR), extreme imbalance flagging
- `GET /api/funding-arb-scanner`: returns top 3 arb pairs, all pairs, avg spread, extreme count (60s cache)
- HTML card `#card-funding-arb-scanner` with APR badge
- `renderFundingArbScanner()` in app.js: ranked table with spread bps, color-coded APR, extreme warning tags, summary footer

## Test plan

- [x] 68 tests in `tests/test_funding_arb_scanner.py` (>30 required)
- [x] Return shape: all required top-level fields present
- [x] Top pairs: exactly 3, sorted by spread_bps descending, all fields validated
- [x] All pairs: covers all 6 symbols, sorted, extreme count consistent
- [x] Computation: scan_funding_rates (18 entries), arb formula, APR formula verified
- [x] Determinism: seeded mock, identical results on repeated calls
- [x] Extreme flags: spread > 2× avg threshold enforced correctly
- [x] Performance: <200ms
- [x] Frontend HTML: card ID, content div, badge span, title
- [x] Frontend JS: render function, API wired, badge, top_pairs, spread_bps, estimated_apr_pct, refresh loop

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)