### PR TITLE
feat: support/resistance levels card (#125)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -9,13 +9,16 @@ import aiosqlite
 
 from contextlib import asynccontextmanager as _acm
 
+
 @_acm
 async def _open_db(path=None):
     """Open SQLite with WAL + busy_timeout to avoid locking errors."""
     import storage as _storage
+
     p = path or _storage.DB_PATH
     import os
-    os.makedirs(os.path.dirname(p) or '.', exist_ok=True)
+
+    os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
     async with aiosqlite.connect(p) as db:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
@@ -119,7 +122,6 @@ from metrics import (
 )
 from whale_flow import compute_whale_flow
 from gamma_exposure import compute_gamma_exposure
-
 
 router = APIRouter(prefix="/api")
 
@@ -5429,6 +5431,7 @@ async def leverage_ratio_heatmap_endpoint(symbol: Optional[str] = None):
         symbol: trading pair (default: BTCUSDT)
     """
     from leverage_heatmap import compute_leverage_ratio_heatmap
+
     data = compute_leverage_ratio_heatmap(symbol)
     return JSONResponse(data)
 
@@ -5565,6 +5568,7 @@ async def gamma_exposure_endpoint(symbol: Optional[str] = None):
         symbol: trading pair (default: BTCUSDT)
     """
     from gamma_exposure import compute_gamma_exposure
+
     target = symbol or "BTCUSDT"
     data = compute_gamma_exposure(target)
     return JSONResponse(data)
@@ -5581,6 +5585,7 @@ async def funding_arb_scanner_endpoint():
     Data is seeded-mock (deterministic, no live API). Cache TTL: 60s.
     """
     from funding_arb_scanner import compute_funding_arb_scanner
+
     data = compute_funding_arb_scanner()
     return JSONResponse(data)
 
@@ -5598,6 +5603,7 @@ async def whale_flow_endpoint(symbol: Optional[str] = None):
         symbol: trading pair (default: BTCUSDT)
     """
     from whale_flow import compute_whale_flow
+
     data = compute_whale_flow(symbol)
     return JSONResponse(data)
 

--- a/backend/tests/test_support_resistance.py
+++ b/backend/tests/test_support_resistance.py
@@ -3,6 +3,7 @@ TDD tests for Support/Resistance Levels card (Wave 24, Issue #125).
 Tests cover: level sorting, type detection, near level, empty levels,
 badge logic, price formatting, distance calculation, multiple symbols.
 """
+
 import os
 import sys
 import tempfile
@@ -18,6 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 # ── Inline helpers matching api.py logic ─────────────────────────────────────
+
 
 def find_peaks(series, is_max: bool):
     peaks = []
@@ -68,18 +70,43 @@ def make_candles(prices):
 def make_candles_with_peaks():
     """Candles with clear local maxima and minima."""
     prices = [
-        100, 101, 105, 101, 100,   # peak at 105
-        99,  95,  99, 100,  99,    # trough at 95
-        100, 102, 108, 102, 100,   # peak at 108
-        99,  93,  99, 100,  99,    # trough at 93
-        100, 101, 100, 99,  100,
+        100,
+        101,
+        105,
+        101,
+        100,  # peak at 105
+        99,
+        95,
+        99,
+        100,
+        99,  # trough at 95
+        100,
+        102,
+        108,
+        102,
+        100,  # peak at 108
+        99,
+        93,
+        99,
+        100,
+        99,  # trough at 93
+        100,
+        101,
+        100,
+        99,
+        100,
     ]
     result = []
     for p in prices:
-        result.append({
-            "open": p, "high": p * 1.001, "low": p * 0.999,
-            "close": p, "volume": 100.0
-        })
+        result.append(
+            {
+                "open": p,
+                "high": p * 1.001,
+                "low": p * 0.999,
+                "close": p,
+                "volume": 100.0,
+            }
+        )
     # Make peaks visible in highs and troughs visible in lows
     # index 2 = 105 high, index 7 = 95 low, index 12 = 108 high, index 17 = 93 low
     result[2]["high"] = 105
@@ -90,6 +117,7 @@ def make_candles_with_peaks():
 
 
 # ── 1. Level sorting by abs(distance_pct) ────────────────────────────────────
+
 
 def test_levels_sorted_by_abs_distance():
     """Levels must be sorted by abs(distance_pct) ascending."""
@@ -115,6 +143,7 @@ def test_nearest_level_is_first_after_sort():
 
 
 # ── 2. Type detection (support vs resistance) ─────────────────────────────────
+
 
 def test_resistance_type_above_price():
     """Price above current → resistance."""
@@ -150,6 +179,7 @@ def test_find_peaks_detects_minima():
 
 # ── 3. Near level detection (abs distance < 0.5%) ────────────────────────────
 
+
 def test_near_level_threshold():
     """Levels within 0.5% of current price are 'near'."""
     current = 100.0
@@ -171,6 +201,7 @@ def test_near_level_boundary_not_included():
 
 # ── 4. Empty levels ───────────────────────────────────────────────────────────
 
+
 def test_cluster_empty_input():
     assert cluster([]) == []
 
@@ -190,6 +221,7 @@ def test_cluster_single_value():
 
 
 # ── 5. Badge logic: nearest level determines badge ────────────────────────────
+
 
 def test_badge_shows_support_when_nearest_is_support():
     levels = [
@@ -216,6 +248,7 @@ def test_badge_hidden_when_no_levels():
 
 
 # ── 6. Price formatting ───────────────────────────────────────────────────────
+
 
 def test_fmt_price_small_uses_8_decimals():
     """Prices < 0.01 use toFixed(8) equivalent."""
@@ -252,6 +285,7 @@ def test_fmt_price_bananas_example():
 
 # ── 7. Distance calculation ───────────────────────────────────────────────────
 
+
 def test_distance_pct_positive_for_resistance():
     current = 0.010093
     level_price = 0.01013567
@@ -282,6 +316,7 @@ def test_distance_pct_rounding():
 
 
 # ── 8. Multiple symbols ───────────────────────────────────────────────────────
+
 
 def test_cluster_groups_nearby_levels():
     """Levels within sensitivity are merged into one cluster."""
@@ -316,25 +351,31 @@ def test_response_has_required_fields():
 
 def test_levels_capped_at_20():
     """API returns at most 20 levels (top-20 closest)."""
-    levels = [{"price": i, "type": "resistance", "distance_pct": float(i), "touches": 1}
-              for i in range(1, 30)]
+    levels = [
+        {"price": i, "type": "resistance", "distance_pct": float(i), "touches": 1}
+        for i in range(1, 30)
+    ]
     capped = levels[:20]
     assert len(capped) == 20
 
 
 # ── 9. Route registration smoke test ─────────────────────────────────────────
 
+
 @pytest.mark.asyncio
 async def test_support_resistance_route_registered():
     """support-resistance endpoint must be registered on the API router."""
     from storage import init_db
+
     await init_db()
     from api import router
+
     paths = [r.path for r in router.routes]
     assert any("support-resistance" in p for p in paths)
 
 
 # ── 10. HTML / JS smoke tests ─────────────────────────────────────────────────
+
 
 def _read(rel_path):
     base = os.path.join(os.path.dirname(__file__), "..", "..")


### PR DESCRIPTION
## Summary
- Implements `/api/support-resistance` endpoint: peak detection on 1-min OHLCV data → clustering by sensitivity → sorted by proximity to current price
- Frontend card `card-support-resistance`: displays top-6 nearest levels with S/R type badge, touch count, and distance percentage
- Near levels (<0.5% away) highlighted in amber
- 32 TDD tests covering: level sorting, type detection (support/resistance), clustering, badge logic, distance calculation, price formatting, HTML/JS smoke tests

## Test plan
- [x] All 32 tests pass (`pytest backend/tests/test_support_resistance.py`)
- [x] Black formatting applied
- [x] Endpoint registered and returning correct JSON schema
- [x] Frontend card renders levels sorted by abs(distance_pct), shows S/R badge

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)