### PR TITLE
fix: restore market-regime v1 schema (score/action/phase/weights) while preserving v2 fields

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -66,6 +66,7 @@ from metrics import (
     detect_funding_extreme,
     detect_cvd_momentum,
     compute_market_regime,
+    compute_market_regime_v1,
     compute_market_regime_v2,
     detect_accumulation_distribution_pattern,
     detect_cross_symbol_oi_spike,
@@ -969,8 +970,15 @@ async def market_regime_endpoint(
 ):
     syms = get_symbols()
     target = symbol if symbol and symbol in syms else syms[0]
-    data = await compute_market_regime_v2(symbol=target)
-    return {"status": "ok", **data}
+    # Get v1 data (score, action, phase, phase_confidence, weights)
+    v1 = await compute_market_regime_v1(symbol=target)
+    # Get v2 data (confidence, volatility, momentum, correlation, regime_history)
+    v2 = await compute_market_regime_v2(symbol=target)
+    # Merge: v1 provides score/action/phase/weights, v2 adds confidence/volatility/etc.
+    merged = {**v2, **v1}
+    merged["score"] = v1.get("score", 0)
+    merged["status"] = "ok"
+    return merged
 
 
 @router.get("/market-regime/all")

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1078,9 +1078,9 @@ async def detect_accumulation_distribution_pattern(symbol: str = None) -> Dict:
     }
 
 
-async def compute_market_regime(symbol: str = None) -> Dict:
+async def compute_market_regime_v1(symbol: str = None) -> Dict:
     """
-    Composite market regime score combining all signals.
+    Composite market regime score combining all signals (v1).
     Returns a score from -100 (extreme bear) to +100 (extreme bull)
     with a confidence level and actionable summary.
     """
@@ -11422,8 +11422,8 @@ async def compute_market_regime_v2(symbol: str = None) -> dict:
 
 # ── Alias for compatibility ───────────────────────────────────────────────────
 async def compute_market_regime(symbol: str = None) -> dict:
-    """Alias to compute_market_regime_v2 for compatibility with existing callers."""
-    return await compute_market_regime_v2(symbol=symbol)
+    """Alias to compute_market_regime_v1 for full schema compatibility."""
+    return await compute_market_regime_v1(symbol=symbol)
 
 
 async def compute_protocol_revenue_card() -> dict:


### PR DESCRIPTION
## Problem

PR #147 merged a version that overrode compute_market_regime with a v2 alias, stripping the original response schema.

The /api/market-regime endpoint stopped returning: score, action, phase, phase_confidence, weights — breaking test_integration_api::TestMarketRegime::test_market_regime.

## Fix
- Rename original compute_market_regime -> compute_market_regime_v1 (preserves v1 schema)
- Repoint compute_market_regime alias to call v1 (all existing callers get correct schema)
- Update /market-regime endpoint to merge both v1+v2 data
- Remove stale untracked backend/tests/test_cross_asset_correlation.py (leftover from aborted AO session)

## Tests
4098/4098 passing