### PR TITLE
feat: Wave 25 — enhanced VPIN order-flow-toxicity (#143)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -9791,14 +9791,44 @@ async def compute_cross_market_correlation() -> dict:
     }
 
 
+def _vpin_toxicity_level(score: float) -> str:
+    """Classify VPIN score into toxicity level."""
+    if score < 0.25:
+        return "low"
+    elif score < 0.50:
+        return "medium"
+    elif score < 0.75:
+        return "high"
+    return "extreme"
+
+
+def _vpin_bucket_class(vpin_window: float) -> str:
+    """Classify per-bucket toxicity class from windowed VPIN."""
+    if vpin_window < 0.20:
+        return "low"
+    elif vpin_window < 0.40:
+        return "medium"
+    elif vpin_window < 0.65:
+        return "high"
+    return "extreme"
+
+
 async def compute_order_flow_toxicity() -> Dict:
     """
-    VPIN: Volume-Synchronized Probability of Informed Trading.
+    Enhanced VPIN: Volume-Synchronized Probability of Informed Trading.
 
     Partitions volume into equal-sized buckets and estimates the fraction of
     informed trading using buy/sell volume imbalance per bucket.
 
     VPIN = (1/n) * sum(|V_buy_i - V_sell_i|) / V_bucket
+
+    Enhanced with:
+    - toxicity_percentile: rank 0–100 against historical distribution
+    - toxicity_alert: True when percentile > 80
+    - alert_threshold: fixed at 80
+    - bucket_classifications: per-bucket toxicity class
+    - symbol_comparison: top-10 symbols ranked by VPIN
+    - vpin_history: last 20 VPIN values for trend
     """
     import random
     from datetime import datetime, timezone
@@ -9808,6 +9838,7 @@ async def compute_order_flow_toxicity() -> Dict:
     # ── Parameters ────────────────────────────────────────────────────────────
     N_BUCKETS = 50
     BUCKET_VOLUME = 1000.0  # each bucket has ~1000 units of volume
+    ALERT_THRESHOLD = 80.0  # alert when percentile > 80
 
     # ── Generate synthetic volume buckets ────────────────────────────────────
     volume_buckets: List[Dict] = []
@@ -9860,14 +9891,7 @@ async def compute_order_flow_toxicity() -> Dict:
     sell_volume_frac = round(total_sell_vol / total_vol, 6)
 
     # ── Toxicity level classification ─────────────────────────────────────────
-    if vpin_score < 0.25:
-        toxicity_level = "low"
-    elif vpin_score < 0.50:
-        toxicity_level = "medium"
-    elif vpin_score < 0.75:
-        toxicity_level = "high"
-    else:
-        toxicity_level = "extreme"
+    toxicity_level = _vpin_toxicity_level(vpin_score)
 
     # ── Informed trading signal ───────────────────────────────────────────────
     if vpin_score >= 0.50:
@@ -9876,6 +9900,72 @@ async def compute_order_flow_toxicity() -> Dict:
         informed_trading_signal = "low_toxicity"
     else:
         informed_trading_signal = "neutral"
+
+    # ── Toxicity percentile rank (0–100) ─────────────────────────────────────
+    # Simulate a historical distribution of 200 VPIN values for percentile rank
+    hist_rng = random.Random(20260321)
+    historical_vpins = sorted(
+        round(max(0.0, min(1.0, hist_rng.gauss(0.35, 0.15))), 6)
+        for _ in range(200)
+    )
+    # Count how many historical values are <= current vpin_score
+    n_below = sum(1 for v in historical_vpins if v <= vpin_score)
+    toxicity_percentile = round(n_below / len(historical_vpins) * 100, 2)
+
+    # ── Alert flag ────────────────────────────────────────────────────────────
+    toxicity_alert = toxicity_percentile > ALERT_THRESHOLD
+
+    # ── Per-bucket toxicity classifications ────────────────────────────────────
+    bucket_classifications: List[Dict] = []
+    for i, b in enumerate(volume_buckets):
+        wvpin = rolling_vpin_50[i]
+        bucket_classifications.append(
+            {
+                "bucket_id": i,
+                "vpin_window": wvpin,
+                "toxicity_class": _vpin_bucket_class(wvpin),
+            }
+        )
+
+    # ── Top-10 symbol comparison ──────────────────────────────────────────────
+    symbols = [
+        "BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT",
+        "ADAUSDT", "AVAXUSDT", "DOTUSDT", "MATICUSDT", "LINKUSDT",
+    ]
+    sym_rng = random.Random(20260321)
+    sym_vpins = []
+    for sym in symbols:
+        sv = round(max(0.0, min(1.0, sym_rng.gauss(0.35, 0.15))), 6)
+        n_below_sym = sum(1 for v in historical_vpins if v <= sv)
+        sym_pct = round(n_below_sym / len(historical_vpins) * 100, 2)
+        sym_vpins.append(
+            {
+                "symbol": sym,
+                "vpin_score": sv,
+                "toxicity_level": _vpin_toxicity_level(sv),
+                "toxicity_percentile": sym_pct,
+            }
+        )
+    # rank by vpin_score descending (1 = highest toxicity)
+    sym_vpins.sort(key=lambda x: x["vpin_score"], reverse=True)
+    symbol_comparison = []
+    for rank, s in enumerate(sym_vpins, start=1):
+        symbol_comparison.append({**s, "rank": rank})
+
+    # ── VPIN history (100 rolling values, expand by simulating 50 more buckets) ─
+    # Generate 50 additional historical buckets with the same seed offset
+    hist_bucket_rng = random.Random(20260322)
+    extra_vpin: List[float] = []
+    prev_buckets = []
+    for i in range(50):
+        bf = hist_bucket_rng.gauss(0.52, 0.12)
+        bf = max(0.05, min(0.95, bf))
+        imb = round(abs(bf - (1.0 - bf)), 6)
+        prev_buckets.append(imb)
+        start = max(0, len(prev_buckets) - window)
+        wv = round(sum(prev_buckets[start:]) / len(prev_buckets[start:]), 6)
+        extra_vpin.append(wv)
+    vpin_history = extra_vpin + rolling_vpin_50  # 50 + 50 = 100
 
     return {
         "vpin_score": vpin_score,
@@ -9886,6 +9976,12 @@ async def compute_order_flow_toxicity() -> Dict:
         "informed_trading_signal": informed_trading_signal,
         "rolling_vpin_50": rolling_vpin_50,
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "toxicity_percentile": toxicity_percentile,
+        "toxicity_alert": toxicity_alert,
+        "alert_threshold": ALERT_THRESHOLD,
+        "bucket_classifications": bucket_classifications,
+        "symbol_comparison": symbol_comparison,
+        "vpin_history": vpin_history,
     }
 
 

--- a/backend/tests/test_order_flow_toxicity.py
+++ b/backend/tests/test_order_flow_toxicity.py
@@ -1,0 +1,432 @@
+"""Tests for compute_order_flow_toxicity() — enhanced VPIN implementation.
+
+72 tests covering all required keys, value ranges, structural invariants,
+determinism, and alert logic.
+"""
+import asyncio
+import math
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from metrics import compute_order_flow_toxicity
+
+REQUIRED_KEYS = {
+    "vpin_score",
+    "buy_volume_frac",
+    "sell_volume_frac",
+    "toxicity_level",
+    "volume_buckets",
+    "informed_trading_signal",
+    "rolling_vpin_50",
+    "timestamp",
+    "toxicity_percentile",
+    "toxicity_alert",
+    "bucket_classifications",
+    "symbol_comparison",
+    "alert_threshold",
+    "vpin_history",
+}
+
+TOXICITY_LEVELS = {"low", "medium", "high", "extreme"}
+INFORMED_SIGNALS = {"high_toxicity", "low_toxicity", "neutral"}
+BUCKET_KEYS = {"bucket_id", "buy_vol", "sell_vol", "imbalance"}
+CLASSIFICATION_KEYS = {"bucket_id", "vpin_window", "toxicity_class"}
+SYMBOL_KEYS = {"symbol", "vpin_score", "toxicity_level", "toxicity_percentile", "rank"}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ── Fixture ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def result():
+    return run(compute_order_flow_toxicity())
+
+
+@pytest.fixture(scope="module")
+def result2():
+    return run(compute_order_flow_toxicity())
+
+
+# ── Return type ──────────────────────────────────────────────────────────────
+
+
+def test_returns_dict(result):
+    assert isinstance(result, dict)
+
+
+# ── All required keys present ────────────────────────────────────────────────
+
+
+def test_has_vpin_score(result):
+    assert "vpin_score" in result
+
+
+def test_has_buy_volume_frac(result):
+    assert "buy_volume_frac" in result
+
+
+def test_has_sell_volume_frac(result):
+    assert "sell_volume_frac" in result
+
+
+def test_has_toxicity_level(result):
+    assert "toxicity_level" in result
+
+
+def test_has_volume_buckets(result):
+    assert "volume_buckets" in result
+
+
+def test_has_informed_trading_signal(result):
+    assert "informed_trading_signal" in result
+
+
+def test_has_rolling_vpin_50(result):
+    assert "rolling_vpin_50" in result
+
+
+def test_has_timestamp(result):
+    assert "timestamp" in result
+
+
+def test_has_toxicity_percentile(result):
+    assert "toxicity_percentile" in result
+
+
+def test_has_toxicity_alert(result):
+    assert "toxicity_alert" in result
+
+
+def test_has_bucket_classifications(result):
+    assert "bucket_classifications" in result
+
+
+def test_has_symbol_comparison(result):
+    assert "symbol_comparison" in result
+
+
+def test_has_alert_threshold(result):
+    assert "alert_threshold" in result
+
+
+def test_has_vpin_history(result):
+    assert "vpin_history" in result
+
+
+def test_all_required_keys(result):
+    assert REQUIRED_KEYS.issubset(result.keys())
+
+
+# ── vpin_score ────────────────────────────────────────────────────────────────
+
+
+def test_vpin_score_in_range(result):
+    assert 0.0 <= result["vpin_score"] <= 1.0
+
+
+def test_vpin_score_is_float(result):
+    assert isinstance(result["vpin_score"], float)
+
+
+def test_vpin_score_matches_mean_imbalance(result):
+    buckets = result["volume_buckets"]
+    expected = sum(b["imbalance"] for b in buckets) / len(buckets)
+    assert math.isclose(result["vpin_score"], expected, rel_tol=1e-5)
+
+
+# ── buy/sell fractions ────────────────────────────────────────────────────────
+
+
+def test_buy_volume_frac_in_range(result):
+    assert 0.0 < result["buy_volume_frac"] < 1.0
+
+
+def test_sell_volume_frac_in_range(result):
+    assert 0.0 < result["sell_volume_frac"] < 1.0
+
+
+def test_fracs_sum_to_one(result):
+    total = result["buy_volume_frac"] + result["sell_volume_frac"]
+    assert math.isclose(total, 1.0, abs_tol=1e-4)
+
+
+# ── toxicity_level ────────────────────────────────────────────────────────────
+
+
+def test_toxicity_level_valid(result):
+    assert result["toxicity_level"] in TOXICITY_LEVELS
+
+
+def test_toxicity_level_is_string(result):
+    assert isinstance(result["toxicity_level"], str)
+
+
+def test_toxicity_level_consistent_with_vpin(result):
+    score = result["vpin_score"]
+    level = result["toxicity_level"]
+    if score < 0.25:
+        assert level == "low"
+    elif score < 0.50:
+        assert level == "medium"
+    elif score < 0.75:
+        assert level == "high"
+    else:
+        assert level == "extreme"
+
+
+# ── informed_trading_signal ───────────────────────────────────────────────────
+
+
+def test_informed_trading_signal_valid(result):
+    assert result["informed_trading_signal"] in INFORMED_SIGNALS
+
+
+def test_informed_trading_signal_consistent_with_vpin(result):
+    score = result["vpin_score"]
+    sig = result["informed_trading_signal"]
+    if score >= 0.50:
+        assert sig == "high_toxicity"
+    elif score <= 0.20:
+        assert sig == "low_toxicity"
+    else:
+        assert sig == "neutral"
+
+
+# ── volume_buckets ────────────────────────────────────────────────────────────
+
+
+def test_volume_buckets_is_list(result):
+    assert isinstance(result["volume_buckets"], list)
+
+
+def test_volume_buckets_length_50(result):
+    assert len(result["volume_buckets"]) == 50
+
+
+def test_volume_buckets_have_required_keys(result):
+    for b in result["volume_buckets"]:
+        assert BUCKET_KEYS.issubset(b.keys())
+
+
+def test_volume_buckets_imbalance_in_range(result):
+    for b in result["volume_buckets"]:
+        assert 0.0 <= b["imbalance"] <= 1.0
+
+
+def test_volume_buckets_buy_sell_sum_approx_1000(result):
+    for b in result["volume_buckets"]:
+        total = b["buy_vol"] + b["sell_vol"]
+        assert math.isclose(total, 1000.0, abs_tol=0.01)
+
+
+def test_volume_buckets_bucket_ids_sequential(result):
+    for i, b in enumerate(result["volume_buckets"]):
+        assert b["bucket_id"] == i
+
+
+# ── rolling_vpin_50 ───────────────────────────────────────────────────────────
+
+
+def test_rolling_vpin_50_is_list(result):
+    assert isinstance(result["rolling_vpin_50"], list)
+
+
+def test_rolling_vpin_50_length_50(result):
+    assert len(result["rolling_vpin_50"]) == 50
+
+
+def test_rolling_vpin_50_values_in_range(result):
+    for v in result["rolling_vpin_50"]:
+        assert 0.0 <= v <= 1.0
+
+
+# ── toxicity_percentile ───────────────────────────────────────────────────────
+
+
+def test_toxicity_percentile_in_range(result):
+    assert 0.0 <= result["toxicity_percentile"] <= 100.0
+
+
+def test_toxicity_percentile_is_float(result):
+    assert isinstance(result["toxicity_percentile"], float)
+
+
+# ── toxicity_alert ────────────────────────────────────────────────────────────
+
+
+def test_toxicity_alert_is_bool(result):
+    assert isinstance(result["toxicity_alert"], bool)
+
+
+def test_toxicity_alert_consistent_with_percentile(result):
+    assert result["toxicity_alert"] == (result["toxicity_percentile"] > 80.0)
+
+
+# ── alert_threshold ───────────────────────────────────────────────────────────
+
+
+def test_alert_threshold_is_80(result):
+    assert result["alert_threshold"] == 80.0
+
+
+def test_alert_threshold_is_float(result):
+    assert isinstance(result["alert_threshold"], float)
+
+
+# ── vpin_history ──────────────────────────────────────────────────────────────
+
+
+def test_vpin_history_is_list(result):
+    assert isinstance(result["vpin_history"], list)
+
+
+def test_vpin_history_length_100(result):
+    assert len(result["vpin_history"]) == 100
+
+
+def test_vpin_history_values_in_range(result):
+    for v in result["vpin_history"]:
+        assert 0.0 <= v <= 1.0
+
+
+# ── bucket_classifications ────────────────────────────────────────────────────
+
+
+def test_bucket_classifications_is_list(result):
+    assert isinstance(result["bucket_classifications"], list)
+
+
+def test_bucket_classifications_length_50(result):
+    assert len(result["bucket_classifications"]) == 50
+
+
+def test_bucket_classifications_have_required_keys(result):
+    for c in result["bucket_classifications"]:
+        assert CLASSIFICATION_KEYS.issubset(c.keys())
+
+
+def test_bucket_classifications_toxicity_class_valid(result):
+    for c in result["bucket_classifications"]:
+        assert c["toxicity_class"] in TOXICITY_LEVELS
+
+
+def test_bucket_classifications_bucket_ids_sequential(result):
+    for i, c in enumerate(result["bucket_classifications"]):
+        assert c["bucket_id"] == i
+
+
+def test_bucket_classifications_vpin_window_matches_rolling(result):
+    for c, rv in zip(result["bucket_classifications"], result["rolling_vpin_50"]):
+        assert c["vpin_window"] == rv
+
+
+# ── symbol_comparison ─────────────────────────────────────────────────────────
+
+
+def test_symbol_comparison_is_list(result):
+    assert isinstance(result["symbol_comparison"], list)
+
+
+def test_symbol_comparison_length_10(result):
+    assert len(result["symbol_comparison"]) == 10
+
+
+def test_symbol_comparison_have_required_keys(result):
+    for s in result["symbol_comparison"]:
+        assert SYMBOL_KEYS.issubset(s.keys())
+
+
+def test_symbol_comparison_ranks_1_to_10(result):
+    ranks = sorted(s["rank"] for s in result["symbol_comparison"])
+    assert ranks == list(range(1, 11))
+
+
+def test_symbol_comparison_ranks_unique(result):
+    ranks = [s["rank"] for s in result["symbol_comparison"]]
+    assert len(ranks) == len(set(ranks))
+
+
+def test_symbol_comparison_sorted_by_vpin_descending(result):
+    scores = [s["vpin_score"] for s in result["symbol_comparison"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_symbol_comparison_vpin_scores_in_range(result):
+    for s in result["symbol_comparison"]:
+        assert 0.0 <= s["vpin_score"] <= 1.0
+
+
+def test_symbol_comparison_toxicity_levels_valid(result):
+    for s in result["symbol_comparison"]:
+        assert s["toxicity_level"] in TOXICITY_LEVELS
+
+
+def test_symbol_comparison_percentiles_in_range(result):
+    for s in result["symbol_comparison"]:
+        assert 0.0 <= s["toxicity_percentile"] <= 100.0
+
+
+def test_symbol_comparison_symbols_are_strings(result):
+    for s in result["symbol_comparison"]:
+        assert isinstance(s["symbol"], str) and len(s["symbol"]) > 0
+
+
+# ── timestamp ─────────────────────────────────────────────────────────────────
+
+
+def test_timestamp_is_string(result):
+    assert isinstance(result["timestamp"], str)
+
+
+def test_timestamp_nonempty(result):
+    assert len(result["timestamp"]) > 0
+
+
+# ── async / determinism ───────────────────────────────────────────────────────
+
+
+def test_function_is_async():
+    import inspect
+    assert inspect.iscoroutinefunction(compute_order_flow_toxicity)
+
+
+def test_determinism_vpin_score(result, result2):
+    assert result["vpin_score"] == result2["vpin_score"]
+
+
+def test_determinism_volume_buckets(result, result2):
+    assert result["volume_buckets"] == result2["volume_buckets"]
+
+
+def test_determinism_rolling_vpin_50(result, result2):
+    assert result["rolling_vpin_50"] == result2["rolling_vpin_50"]
+
+
+def test_determinism_vpin_history(result, result2):
+    assert result["vpin_history"] == result2["vpin_history"]
+
+
+def test_determinism_toxicity_percentile(result, result2):
+    assert result["toxicity_percentile"] == result2["toxicity_percentile"]
+
+
+def test_determinism_toxicity_alert(result, result2):
+    assert result["toxicity_alert"] == result2["toxicity_alert"]
+
+
+def test_determinism_symbol_comparison(result, result2):
+    for s1, s2 in zip(result["symbol_comparison"], result2["symbol_comparison"]):
+        assert s1["symbol"] == s2["symbol"]
+        assert s1["vpin_score"] == s2["vpin_score"]
+        assert s1["rank"] == s2["rank"]
+
+
+def test_determinism_bucket_classifications(result, result2):
+    assert result["bucket_classifications"] == result2["bucket_classifications"]


### PR DESCRIPTION
## Summary

Enhanced `compute_order_flow_toxicity()` with all features from issue #143:

- **toxicity_percentile**: 0–100 rank against a 200-sample historical VPIN distribution
- **toxicity_alert**: True when percentile > 80th (informed trading event)
- **alert_threshold**: 80.0 (fixed threshold)
- **bucket_classifications**: per-bucket toxicity class (low/medium/high/extreme) based on windowed VPIN
- **symbol_comparison**: top-10 symbols ranked by VPIN score, each with toxicity_level and percentile
- **vpin_history**: 100-length rolling VPIN series for trend charts

## Test plan
- 72 tests added in `backend/tests/test_order_flow_toxicity.py`
- All 783 tests passing (711 baseline + 72 new)
- Deterministic output (seed 20260320/21/22)

Closes #143