### PR TITLE
feat: Wave 25 — miner-flow-signals (#146)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -127,6 +127,7 @@ from metrics import (
     compute_smart_money_flow,
     compute_vol_regime_hmm,
     compute_social_sentiment_momentum,
+    compute_miner_flow_signals,
 )
 from whale_flow import compute_whale_flow
 from gamma_exposure import compute_gamma_exposure
@@ -5847,3 +5848,9 @@ async def validator_activity_endpoint():
     """Validator activity: effectiveness rate, queue pressure, staking APY."""
     data = await compute_validator_activity()
     return JSONResponse(data)
+
+
+@router.get("/miner-flow-signals")
+async def miner_flow_signals_endpoint():
+    """Miner flow signals: wallet outflow rate, reserve ratio, price correlation, 30d forecast."""
+    return JSONResponse(await compute_miner_flow_signals())

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -12764,3 +12764,103 @@ async def compute_social_sentiment_momentum() -> Dict:
         "trending_tokens": trending_tokens,
         "timestamp": timestamp,
     }
+
+
+# ── Wave 25 · Task 5 — Miner Flow Signals ─────────────────────────────────────
+
+async def compute_miner_flow_signals() -> dict:
+    """Miner flow signals: wallet outflow rate, reserve ratio, price correlation,
+    30-day sell pressure forecast.
+
+    Deterministic seed 20260323. No real external calls.
+    """
+    import datetime as _dt_mfs
+
+    _rng = _random.Random(20260323)
+
+    # ── Daily BTC outflow from miner wallets ────────────────────────────────────
+    outflow_rate_btc: float = round(_rng.uniform(200.0, 1500.0), 2)
+
+    # ── 7-day average outflow ───────────────────────────────────────────────────
+    outflow_7d: list = [round(_rng.uniform(200.0, 1500.0), 2) for _ in range(7)]
+    outflow_rate_7d_avg: float = round(sum(outflow_7d) / 7.0, 2)
+
+    # ── Outflow trend ───────────────────────────────────────────────────────────
+    if outflow_rate_btc > outflow_rate_7d_avg * 1.05:
+        outflow_trend = "increasing"
+    elif outflow_rate_btc < outflow_rate_7d_avg * 0.95:
+        outflow_trend = "decreasing"
+    else:
+        outflow_trend = "stable"
+
+    # ── Miner reserve (BTC) ─────────────────────────────────────────────────────
+    reserve_btc: float = round(_rng.uniform(50_000.0, 300_000.0), 2)
+    peak_reserve_btc: float = round(reserve_btc * _rng.uniform(1.05, 1.80), 2)
+    reserve_ratio: float = round(min(1.0, reserve_btc / peak_reserve_btc), 4)
+
+    # ── Reserve trend ───────────────────────────────────────────────────────────
+    _rv = _rng.random()
+    if _rv < 0.33:
+        reserve_trend = "accumulating"
+    elif _rv < 0.67:
+        reserve_trend = "depleting"
+    else:
+        reserve_trend = "stable"
+
+    # ── 90-day price correlation (outflow vs drawdown) ─────────────────────────
+    price_correlation_90d: float = round(_rng.uniform(-1.0, 1.0), 4)
+
+    # ── Historical drawdowns (10 events, fixed base date for determinism) ──────
+    historical_drawdowns: list = []
+    _base = _dt_mfs.date(2025, 12, 18)  # fixed anchor → deterministic dates
+    for i in range(10):
+        event_date = _base - _dt_mfs.timedelta(days=(9 - i) * 9)
+        outflow_spike: float = round(_rng.uniform(500.0, 3000.0), 2)
+        price_drawdown_pct: float = round(-abs(_rng.uniform(0.5, 25.0)), 2)
+        historical_drawdowns.append(
+            {
+                "date": event_date.strftime("%Y-%m-%d"),
+                "outflow_spike": outflow_spike,
+                "price_drawdown_pct": price_drawdown_pct,
+            }
+        )
+
+    # ── 30-day sell pressure forecast (BTC/day) ─────────────────────────────────
+    sell_pressure_forecast_30d: list = [
+        round(_rng.uniform(200.0, 1500.0), 2) for _ in range(30)
+    ]
+
+    # ── Sell pressure trend ─────────────────────────────────────────────────────
+    _first_half_avg = sum(sell_pressure_forecast_30d[:15]) / 15.0
+    _second_half_avg = sum(sell_pressure_forecast_30d[15:]) / 15.0
+    if _second_half_avg > _first_half_avg * 1.05:
+        sell_pressure_trend = "rising"
+    elif _second_half_avg < _first_half_avg * 0.95:
+        sell_pressure_trend = "falling"
+    else:
+        sell_pressure_trend = "neutral"
+
+    # ── Miner capitulation risk ─────────────────────────────────────────────────
+    if reserve_ratio < 0.5 and outflow_trend == "increasing":
+        miner_capitulation_risk = "high"
+    elif reserve_ratio < 0.7 or outflow_trend == "increasing":
+        miner_capitulation_risk = "medium"
+    else:
+        miner_capitulation_risk = "low"
+
+    timestamp: str = _dt_mfs.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return {
+        "outflow_rate_btc": outflow_rate_btc,
+        "outflow_rate_7d_avg": outflow_rate_7d_avg,
+        "outflow_trend": outflow_trend,
+        "reserve_ratio": reserve_ratio,
+        "reserve_btc": reserve_btc,
+        "reserve_trend": reserve_trend,
+        "price_correlation_90d": price_correlation_90d,
+        "historical_drawdowns": historical_drawdowns,
+        "sell_pressure_forecast_30d": sell_pressure_forecast_30d,
+        "sell_pressure_trend": sell_pressure_trend,
+        "miner_capitulation_risk": miner_capitulation_risk,
+        "timestamp": timestamp,
+    }

--- a/backend/tests/test_miner_flow_signals.py
+++ b/backend/tests/test_miner_flow_signals.py
@@ -1,0 +1,429 @@
+"""Tests for compute_miner_flow_signals() — Wave 25, Task 5.
+
+50+ tests covering all required keys, value ranges, structural invariants,
+determinism, historical drawdowns, sell pressure forecast, and structural checks.
+"""
+import asyncio
+import re
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from metrics import compute_miner_flow_signals
+
+REQUIRED_KEYS = {
+    "outflow_rate_btc",
+    "outflow_rate_7d_avg",
+    "outflow_trend",
+    "reserve_ratio",
+    "reserve_btc",
+    "reserve_trend",
+    "price_correlation_90d",
+    "historical_drawdowns",
+    "sell_pressure_forecast_30d",
+    "sell_pressure_trend",
+    "miner_capitulation_risk",
+    "timestamp",
+}
+
+OUTFLOW_TRENDS = {"increasing", "decreasing", "stable"}
+RESERVE_TRENDS = {"accumulating", "depleting", "stable"}
+SELL_PRESSURE_TRENDS = {"rising", "falling", "neutral"}
+CAPITULATION_RISKS = {"low", "medium", "high"}
+DRAWDOWN_KEYS = {"date", "outflow_spike", "price_drawdown_pct"}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def result():
+    return run(compute_miner_flow_signals())
+
+
+@pytest.fixture(scope="module")
+def result2():
+    return run(compute_miner_flow_signals())
+
+
+# ── Return type ────────────────────────────────────────────────────────────────
+
+
+def test_returns_dict(result):
+    assert isinstance(result, dict)
+
+
+# ── Required keys ──────────────────────────────────────────────────────────────
+
+
+def test_has_outflow_rate_btc(result):
+    assert "outflow_rate_btc" in result
+
+
+def test_has_outflow_rate_7d_avg(result):
+    assert "outflow_rate_7d_avg" in result
+
+
+def test_has_outflow_trend(result):
+    assert "outflow_trend" in result
+
+
+def test_has_reserve_ratio(result):
+    assert "reserve_ratio" in result
+
+
+def test_has_reserve_btc(result):
+    assert "reserve_btc" in result
+
+
+def test_has_reserve_trend(result):
+    assert "reserve_trend" in result
+
+
+def test_has_price_correlation_90d(result):
+    assert "price_correlation_90d" in result
+
+
+def test_has_historical_drawdowns(result):
+    assert "historical_drawdowns" in result
+
+
+def test_has_sell_pressure_forecast_30d(result):
+    assert "sell_pressure_forecast_30d" in result
+
+
+def test_has_sell_pressure_trend(result):
+    assert "sell_pressure_trend" in result
+
+
+def test_has_miner_capitulation_risk(result):
+    assert "miner_capitulation_risk" in result
+
+
+def test_has_timestamp(result):
+    assert "timestamp" in result
+
+
+def test_all_required_keys_present(result):
+    assert REQUIRED_KEYS.issubset(result.keys())
+
+
+# ── outflow_rate_btc ───────────────────────────────────────────────────────────
+
+
+def test_outflow_rate_btc_positive(result):
+    assert result["outflow_rate_btc"] > 0
+
+
+def test_outflow_rate_btc_is_float(result):
+    assert isinstance(result["outflow_rate_btc"], float)
+
+
+def test_outflow_rate_btc_reasonable_range(result):
+    assert 100.0 <= result["outflow_rate_btc"] <= 2000.0
+
+
+# ── outflow_rate_7d_avg ────────────────────────────────────────────────────────
+
+
+def test_outflow_rate_7d_avg_positive(result):
+    assert result["outflow_rate_7d_avg"] > 0
+
+
+def test_outflow_rate_7d_avg_is_float(result):
+    assert isinstance(result["outflow_rate_7d_avg"], float)
+
+
+def test_outflow_rate_7d_avg_reasonable_range(result):
+    assert 100.0 <= result["outflow_rate_7d_avg"] <= 2000.0
+
+
+# ── outflow_trend ──────────────────────────────────────────────────────────────
+
+
+def test_outflow_trend_valid(result):
+    assert result["outflow_trend"] in OUTFLOW_TRENDS
+
+
+def test_outflow_trend_is_str(result):
+    assert isinstance(result["outflow_trend"], str)
+
+
+# ── reserve_ratio ──────────────────────────────────────────────────────────────
+
+
+def test_reserve_ratio_in_range(result):
+    assert 0.0 <= result["reserve_ratio"] <= 1.0
+
+
+def test_reserve_ratio_is_float(result):
+    assert isinstance(result["reserve_ratio"], float)
+
+
+def test_reserve_ratio_positive(result):
+    assert result["reserve_ratio"] > 0
+
+
+# ── reserve_btc ────────────────────────────────────────────────────────────────
+
+
+def test_reserve_btc_positive(result):
+    assert result["reserve_btc"] > 0
+
+
+def test_reserve_btc_is_float(result):
+    assert isinstance(result["reserve_btc"], float)
+
+
+def test_reserve_btc_reasonable_range(result):
+    assert 1_000.0 <= result["reserve_btc"] <= 1_000_000.0
+
+
+# ── reserve_trend ──────────────────────────────────────────────────────────────
+
+
+def test_reserve_trend_valid(result):
+    assert result["reserve_trend"] in RESERVE_TRENDS
+
+
+def test_reserve_trend_is_str(result):
+    assert isinstance(result["reserve_trend"], str)
+
+
+# ── price_correlation_90d ──────────────────────────────────────────────────────
+
+
+def test_price_correlation_90d_in_range(result):
+    assert -1.0 <= result["price_correlation_90d"] <= 1.0
+
+
+def test_price_correlation_90d_is_float(result):
+    assert isinstance(result["price_correlation_90d"], float)
+
+
+# ── historical_drawdowns ───────────────────────────────────────────────────────
+
+
+def test_historical_drawdowns_is_list(result):
+    assert isinstance(result["historical_drawdowns"], list)
+
+
+def test_historical_drawdowns_length_10(result):
+    assert len(result["historical_drawdowns"]) == 10
+
+
+def test_historical_drawdowns_items_are_dicts(result):
+    for item in result["historical_drawdowns"]:
+        assert isinstance(item, dict)
+
+
+def test_historical_drawdowns_have_required_keys(result):
+    for item in result["historical_drawdowns"]:
+        assert DRAWDOWN_KEYS.issubset(item.keys()), f"Missing keys in {item}"
+
+
+def test_historical_drawdowns_date_is_str(result):
+    for item in result["historical_drawdowns"]:
+        assert isinstance(item["date"], str)
+
+
+def test_historical_drawdowns_date_nonempty(result):
+    for item in result["historical_drawdowns"]:
+        assert len(item["date"]) > 0
+
+
+def test_historical_drawdowns_date_iso_format(result):
+    iso_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+    for item in result["historical_drawdowns"]:
+        assert iso_re.match(item["date"]), f"Date not ISO: {item['date']}"
+
+
+def test_historical_drawdowns_outflow_spike_positive(result):
+    for item in result["historical_drawdowns"]:
+        assert item["outflow_spike"] > 0
+
+
+def test_historical_drawdowns_price_drawdown_nonpositive(result):
+    for item in result["historical_drawdowns"]:
+        assert item["price_drawdown_pct"] <= 0
+
+
+def test_historical_drawdowns_outflow_spike_is_float(result):
+    for item in result["historical_drawdowns"]:
+        assert isinstance(item["outflow_spike"], float)
+
+
+def test_historical_drawdowns_price_drawdown_is_float(result):
+    for item in result["historical_drawdowns"]:
+        assert isinstance(item["price_drawdown_pct"], float)
+
+
+# ── sell_pressure_forecast_30d ────────────────────────────────────────────────
+
+
+def test_sell_pressure_forecast_is_list(result):
+    assert isinstance(result["sell_pressure_forecast_30d"], list)
+
+
+def test_sell_pressure_forecast_length_30(result):
+    assert len(result["sell_pressure_forecast_30d"]) == 30
+
+
+def test_sell_pressure_forecast_all_positive(result):
+    for v in result["sell_pressure_forecast_30d"]:
+        assert v > 0
+
+
+def test_sell_pressure_forecast_values_are_floats(result):
+    for v in result["sell_pressure_forecast_30d"]:
+        assert isinstance(v, float)
+
+
+def test_sell_pressure_forecast_reasonable_range(result):
+    for v in result["sell_pressure_forecast_30d"]:
+        assert 100.0 <= v <= 2000.0
+
+
+# ── sell_pressure_trend ────────────────────────────────────────────────────────
+
+
+def test_sell_pressure_trend_valid(result):
+    assert result["sell_pressure_trend"] in SELL_PRESSURE_TRENDS
+
+
+def test_sell_pressure_trend_is_str(result):
+    assert isinstance(result["sell_pressure_trend"], str)
+
+
+# ── miner_capitulation_risk ────────────────────────────────────────────────────
+
+
+def test_miner_capitulation_risk_valid(result):
+    assert result["miner_capitulation_risk"] in CAPITULATION_RISKS
+
+
+def test_miner_capitulation_risk_is_str(result):
+    assert isinstance(result["miner_capitulation_risk"], str)
+
+
+# ── timestamp ─────────────────────────────────────────────────────────────────
+
+
+def test_timestamp_is_str(result):
+    assert isinstance(result["timestamp"], str)
+
+
+def test_timestamp_nonempty(result):
+    assert len(result["timestamp"]) > 0
+
+
+def test_timestamp_iso_format(result):
+    ts = result["timestamp"]
+    assert "T" in ts, f"Timestamp missing 'T': {ts}"
+
+
+# ── Determinism (seeded random fields) ────────────────────────────────────────
+
+
+def test_determinism_outflow_rate_btc(result, result2):
+    assert result["outflow_rate_btc"] == result2["outflow_rate_btc"]
+
+
+def test_determinism_outflow_rate_7d_avg(result, result2):
+    assert result["outflow_rate_7d_avg"] == result2["outflow_rate_7d_avg"]
+
+
+def test_determinism_outflow_trend(result, result2):
+    assert result["outflow_trend"] == result2["outflow_trend"]
+
+
+def test_determinism_reserve_btc(result, result2):
+    assert result["reserve_btc"] == result2["reserve_btc"]
+
+
+def test_determinism_reserve_ratio(result, result2):
+    assert result["reserve_ratio"] == result2["reserve_ratio"]
+
+
+def test_determinism_reserve_trend(result, result2):
+    assert result["reserve_trend"] == result2["reserve_trend"]
+
+
+def test_determinism_price_correlation(result, result2):
+    assert result["price_correlation_90d"] == result2["price_correlation_90d"]
+
+
+def test_determinism_forecast_first_value(result, result2):
+    assert result["sell_pressure_forecast_30d"][0] == result2["sell_pressure_forecast_30d"][0]
+
+
+def test_determinism_sell_pressure_trend(result, result2):
+    assert result["sell_pressure_trend"] == result2["sell_pressure_trend"]
+
+
+def test_determinism_capitulation_risk(result, result2):
+    assert result["miner_capitulation_risk"] == result2["miner_capitulation_risk"]
+
+
+def test_determinism_drawdown_dates(result, result2):
+    dates1 = [d["date"] for d in result["historical_drawdowns"]]
+    dates2 = [d["date"] for d in result2["historical_drawdowns"]]
+    assert dates1 == dates2
+
+
+def test_determinism_drawdown_spikes(result, result2):
+    spikes1 = [d["outflow_spike"] for d in result["historical_drawdowns"]]
+    spikes2 = [d["outflow_spike"] for d in result2["historical_drawdowns"]]
+    assert spikes1 == spikes2
+
+
+# ── Async / function shape ─────────────────────────────────────────────────────
+
+
+def test_function_is_async():
+    import inspect
+    assert inspect.iscoroutinefunction(compute_miner_flow_signals)
+
+
+def test_asyncio_run_works():
+    data = asyncio.run(compute_miner_flow_signals())
+    assert isinstance(data, dict)
+
+
+# ── Structural tests ───────────────────────────────────────────────────────────
+
+
+def test_route_registered_in_api_py():
+    api_path = os.path.join(os.path.dirname(__file__), "..", "api.py")
+    content = open(api_path).read()
+    assert "/miner-flow-signals" in content, "/miner-flow-signals route missing from api.py"
+
+
+def test_html_card_exists():
+    html_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "frontend", "index.html"
+    )
+    content = open(html_path).read()
+    assert "miner-flow-signals-card" in content, "miner-flow-signals-card missing from index.html"
+
+
+def test_js_render_function_exists():
+    js_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "frontend", "app.js"
+    )
+    content = open(js_path).read()
+    assert "renderMinerFlowSignals" in content, "renderMinerFlowSignals missing from app.js"
+
+
+def test_js_api_call_exists():
+    js_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "frontend", "app.js"
+    )
+    content = open(js_path).read()
+    assert "/miner-flow-signals" in content, "/miner-flow-signals call missing from app.js"

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2602,6 +2602,8 @@ async function refresh() {
     await Promise.all([safe(renderSmartMoneyFlow), safe(renderVolatilityRegimeHMM)]);
     // Batch 41: social sentiment momentum (Wave 25)
     await Promise.all([safe(refreshSocialSentimentMomentum)]);
+    // Batch 42: miner flow signals (Wave 25)
+    await Promise.all([safe(fetchMinerFlowSignals)]);
   } finally {
     _refreshRunning = false;
   }
@@ -5700,6 +5702,47 @@ async function refreshSocialSentimentMomentum() {
     <div style="font-size:10px;color:var(--muted);margin-top:4px">
       <span style="margin-right:4px">trending:</span>${tokenRows}
     </div>`;
+}
+
+// ── Miner Flow Signals ─────────────────────────────────────────────────────────
+async function fetchMinerFlowSignals() {
+  try {
+    const res = await fetch('/api/miner-flow-signals');
+    const data = await res.json();
+    renderMinerFlowSignals(data);
+  } catch (e) {
+    const el = document.getElementById('miner-flow-signals-content');
+    if (el) el.textContent = 'Error loading miner flow signals.';
+  }
+}
+
+function renderMinerFlowSignals(data) {
+  const el = document.getElementById('miner-flow-signals-content');
+  if (!el) return;
+
+  const risk = (data.miner_capitulation_risk || 'low').toLowerCase();
+  const riskCol = risk === 'high' ? 'var(--bear)' : risk === 'medium' ? 'var(--warn, #f0a500)' : 'var(--bull)';
+  const trendCol = (t) => t === 'increasing' || t === 'rising' ? 'var(--bear)' : t === 'decreasing' || t === 'falling' ? 'var(--bull)' : 'var(--muted)';
+  const reserveCol = data.reserve_trend === 'accumulating' ? 'var(--bull)' : data.reserve_trend === 'depleting' ? 'var(--bear)' : 'var(--muted)';
+
+  const forecast = (data.sell_pressure_forecast_30d || []).slice(0, 7);
+  const forecastStr = forecast.map(v => v.toFixed(0)).join(', ');
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>outflow: <b>${(data.outflow_rate_btc || 0).toFixed(1)} BTC/day</b> <span style="color:${trendCol(data.outflow_trend)}">(${data.outflow_trend || '—'})</span></span>
+      <span>7d avg: <b>${(data.outflow_rate_7d_avg || 0).toFixed(1)} BTC</b></span>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>reserve: <b>${((data.reserve_btc || 0) / 1000).toFixed(1)}k BTC</b> <span style="color:${reserveCol}">(${data.reserve_trend || '—'})</span></span>
+      <span>ratio: <b>${((data.reserve_ratio || 0) * 100).toFixed(1)}%</b></span>
+      <span>corr 90d: <b>${(data.price_correlation_90d || 0).toFixed(3)}</b></span>
+    </div>
+    <div style="font-size:10px;color:var(--muted);margin-bottom:4px;display:flex;gap:10px;flex-wrap:wrap">
+      <span>sell pressure trend: <b style="color:${trendCol(data.sell_pressure_trend)}">${data.sell_pressure_trend || '—'}</b></span>
+      <span>cap risk: <b style="color:${riskCol}">${risk}</b></span>
+    </div>
+    <div style="font-size:10px;color:var(--muted)">forecast (7d): <b>${forecastStr}</b> BTC/day</div>`;
 }
 
 // ── Bootstrap on Load ──────────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1021,6 +1021,15 @@
     <div id="leverage-heatmap-content" style="font-size:11px;">Loading…</div>
   </section>
 
+  <section class="card" id="miner-flow-signals-card">
+    <div class="card-header">
+      <span class="card-title">Miner Flow Signals</span>
+      <span id="miner-flow-signals-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">outflow rate · reserve ratio · sell pressure forecast</span>
+    </div>
+    <div id="miner-flow-signals-content" style="font-size:11px;">Loading…</div>
+  </section>
+
 </main>
 
 <script src="app.js?v=110"></script>


### PR DESCRIPTION
## Summary
- Adds `compute_miner_flow_signals()` to `backend/metrics.py` with deterministic seeded random (seed 20260323)
- New endpoint `GET /api/miner-flow-signals` returning outflow rate, reserve ratio, price correlation, and 30-day sell pressure forecast
- Frontend card (`miner-flow-signals-card`) in `index.html` + `renderMinerFlowSignals()` in `app.js`
- 73 tests in `backend/tests/test_miner_flow_signals.py` (928 total passing)

## Test plan
- [x] All 73 new tests pass
- [x] Full backend suite: 928 passed, 0 failures
- [x] Determinism verified: seeded random produces identical results across calls
- [x] All keys, value ranges, structural (route/HTML/JS) checks pass

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)