### PR TITLE
feat: Wave 25 — derivatives-term-structure (#145)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -128,6 +128,7 @@ from metrics import (
     compute_vol_regime_hmm,
     compute_social_sentiment_momentum,
     compute_miner_flow_signals,
+    compute_derivatives_term_structure,
 )
 from whale_flow import compute_whale_flow
 from gamma_exposure import compute_gamma_exposure
@@ -5849,8 +5850,14 @@ async def validator_activity_endpoint():
     data = await compute_validator_activity()
     return JSONResponse(data)
 
-
 @router.get("/miner-flow-signals")
 async def miner_flow_signals_endpoint():
     """Miner flow signals: wallet outflow rate, reserve ratio, price correlation, 30d forecast."""
     return JSONResponse(await compute_miner_flow_signals())
+
+@router.get("/derivatives-term-structure")
+async def derivatives_term_structure_endpoint():
+    """Derivatives term structure: perp/quarterly/bi-quarterly OI distribution,
+    annualised basis per tenor, contango/backwardation indicator, roll cost."""
+    data = await compute_derivatives_term_structure()
+    return JSONResponse(data)

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -12864,3 +12864,103 @@ async def compute_miner_flow_signals() -> dict:
         "miner_capitulation_risk": miner_capitulation_risk,
         "timestamp": timestamp,
     }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Wave 25 — Derivatives Term Structure
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def compute_derivatives_term_structure() -> dict:
+    """Derivatives term structure: perp/quarterly/bi-quarterly OI distribution,
+    annualised basis per tenor, contango/backwardation indicator, roll cost.
+    """
+    import datetime as _dt
+    import random as _random
+
+    _rng = _random.Random(20260322)
+
+    # ── OI by tenor (USD notional) ────────────────────────────────────────────
+    perp_oi_usd: float = round(_rng.uniform(80_000_000, 400_000_000), 2)
+    qtr_oi_usd: float = round(_rng.uniform(20_000_000, 150_000_000), 2)
+    biqtr_oi_usd: float = round(_rng.uniform(5_000_000, 60_000_000), 2)
+
+    total_oi: float = perp_oi_usd + qtr_oi_usd + biqtr_oi_usd
+
+    perp_pct: float = round(perp_oi_usd / total_oi * 100.0, 4)
+    qtr_pct: float = round(qtr_oi_usd / total_oi * 100.0, 4)
+    biqtr_pct: float = round(100.0 - perp_pct - qtr_pct, 4)
+
+    oi_distribution: dict = {
+        "perpetual": perp_pct,
+        "quarterly": qtr_pct,
+        "bi_quarterly": biqtr_pct,
+    }
+
+    # ── Days to expiry ────────────────────────────────────────────────────────
+    qtr_dte: int = int(_rng.randint(7, 89))      # quarterly: 7–89 days
+    biqtr_dte: int = int(_rng.randint(90, 180))  # bi-quarterly: 90–180 days
+
+    # ── Annualised basis (% pa) ───────────────────────────────────────────────
+    perp_basis: float = round(_rng.uniform(-2.0, 2.0), 4)    # perps have near-zero basis
+    qtr_basis: float = round(_rng.uniform(-5.0, 15.0), 4)
+    biqtr_basis: float = round(_rng.uniform(-5.0, 20.0), 4)
+
+    # ── Tenors list ───────────────────────────────────────────────────────────
+    tenors: list = [
+        {
+            "tenor": "perpetual",
+            "oi_usd": perp_oi_usd,
+            "oi_pct": perp_pct,
+            "basis_annualized": perp_basis,
+            "days_to_expiry": 0,
+        },
+        {
+            "tenor": "quarterly",
+            "oi_usd": qtr_oi_usd,
+            "oi_pct": qtr_pct,
+            "basis_annualized": qtr_basis,
+            "days_to_expiry": qtr_dte,
+        },
+        {
+            "tenor": "bi_quarterly",
+            "oi_usd": biqtr_oi_usd,
+            "oi_pct": biqtr_pct,
+            "basis_annualized": biqtr_basis,
+            "days_to_expiry": biqtr_dte,
+        },
+    ]
+
+    # ── Contango / backwardation ──────────────────────────────────────────────
+    if qtr_basis > 0 and biqtr_basis > qtr_basis:
+        contango_backwardation: str = "contango"
+    elif qtr_basis < 0 and biqtr_basis < qtr_basis:
+        contango_backwardation = "backwardation"
+    else:
+        contango_backwardation = "flat"
+
+    # ── Roll cost (bps) ───────────────────────────────────────────────────────
+    # Basis difference between quarterly and perpetual, converted to bps
+    roll_cost_bps: float = round((qtr_basis - perp_basis) * 100.0, 4)
+
+    # ── Structure health ──────────────────────────────────────────────────────
+    # "healthy"  — normal upward-sloping positive basis curve
+    # "inverted" — near-term basis > far-term basis (inverted curve)
+    # "normal"   — flat or mixed
+    if qtr_basis > 0 and biqtr_basis >= qtr_basis:
+        structure_health: str = "healthy"
+    elif qtr_basis > biqtr_basis and qtr_basis > 0:
+        structure_health = "inverted"
+    else:
+        structure_health = "normal"
+
+    timestamp: str = _dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return {
+        "oi_distribution": oi_distribution,
+        "tenors": tenors,
+        "contango_backwardation": contango_backwardation,
+        "roll_cost_bps": roll_cost_bps,
+        "symbol": "BTC",
+        "timestamp": timestamp,
+        "structure_health": structure_health,
+    }

--- a/backend/tests/test_derivatives_term_structure.py
+++ b/backend/tests/test_derivatives_term_structure.py
@@ -1,0 +1,348 @@
+"""Tests for compute_derivatives_term_structure() — Wave 25.
+
+55 tests covering all required keys, value ranges, structural invariants,
+tenor ordering, determinism, and business logic.
+"""
+import asyncio
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from metrics import compute_derivatives_term_structure
+
+REQUIRED_KEYS = {
+    "oi_distribution",
+    "tenors",
+    "contango_backwardation",
+    "roll_cost_bps",
+    "symbol",
+    "timestamp",
+    "structure_health",
+}
+
+OI_DIST_KEYS = {"perpetual", "quarterly", "bi_quarterly"}
+TENOR_KEYS = {"tenor", "oi_usd", "oi_pct", "basis_annualized", "days_to_expiry"}
+VALID_TENORS = {"perpetual", "quarterly", "bi_quarterly"}
+VALID_CB = {"contango", "backwardation", "flat"}
+VALID_HEALTH = {"healthy", "inverted", "normal"}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def result():
+    return run(compute_derivatives_term_structure())
+
+
+@pytest.fixture(scope="module")
+def result2():
+    return run(compute_derivatives_term_structure())
+
+
+@pytest.fixture(scope="module")
+def oi_dist(result):
+    return result["oi_distribution"]
+
+
+@pytest.fixture(scope="module")
+def tenors(result):
+    return result["tenors"]
+
+
+@pytest.fixture(scope="module")
+def perp_tenor(tenors):
+    return next(t for t in tenors if t["tenor"] == "perpetual")
+
+
+@pytest.fixture(scope="module")
+def qtr_tenor(tenors):
+    return next(t for t in tenors if t["tenor"] == "quarterly")
+
+
+@pytest.fixture(scope="module")
+def biqtr_tenor(tenors):
+    return next(t for t in tenors if t["tenor"] == "bi_quarterly")
+
+
+# ── Return type ───────────────────────────────────────────────────────────────
+
+
+def test_returns_dict(result):
+    assert isinstance(result, dict)
+
+
+def test_is_async():
+    import inspect
+    assert inspect.iscoroutinefunction(compute_derivatives_term_structure)
+
+
+# ── All required top-level keys ───────────────────────────────────────────────
+
+
+def test_all_required_keys(result):
+    assert REQUIRED_KEYS.issubset(result.keys())
+
+
+def test_has_oi_distribution(result):
+    assert "oi_distribution" in result
+
+
+def test_has_tenors(result):
+    assert "tenors" in result
+
+
+def test_has_contango_backwardation(result):
+    assert "contango_backwardation" in result
+
+
+def test_has_roll_cost_bps(result):
+    assert "roll_cost_bps" in result
+
+
+def test_has_symbol(result):
+    assert "symbol" in result
+
+
+def test_has_timestamp(result):
+    assert "timestamp" in result
+
+
+def test_has_structure_health(result):
+    assert "structure_health" in result
+
+
+# ── oi_distribution ───────────────────────────────────────────────────────────
+
+
+def test_oi_distribution_is_dict(oi_dist):
+    assert isinstance(oi_dist, dict)
+
+
+def test_oi_distribution_has_perpetual(oi_dist):
+    assert "perpetual" in oi_dist
+
+
+def test_oi_distribution_has_quarterly(oi_dist):
+    assert "quarterly" in oi_dist
+
+
+def test_oi_distribution_has_bi_quarterly(oi_dist):
+    assert "bi_quarterly" in oi_dist
+
+
+def test_oi_distribution_keys(oi_dist):
+    assert OI_DIST_KEYS == set(oi_dist.keys())
+
+
+def test_oi_distribution_sum_to_100(oi_dist):
+    total = sum(oi_dist.values())
+    assert abs(total - 100.0) < 0.01
+
+
+def test_oi_dist_perpetual_in_range(oi_dist):
+    assert 0.0 <= oi_dist["perpetual"] <= 100.0
+
+
+def test_oi_dist_quarterly_in_range(oi_dist):
+    assert 0.0 <= oi_dist["quarterly"] <= 100.0
+
+
+def test_oi_dist_bi_quarterly_in_range(oi_dist):
+    assert 0.0 <= oi_dist["bi_quarterly"] <= 100.0
+
+
+def test_oi_dist_perpetual_is_float(oi_dist):
+    assert isinstance(oi_dist["perpetual"], float)
+
+
+def test_oi_dist_quarterly_is_float(oi_dist):
+    assert isinstance(oi_dist["quarterly"], float)
+
+
+def test_oi_dist_bi_quarterly_is_float(oi_dist):
+    assert isinstance(oi_dist["bi_quarterly"], float)
+
+
+# ── tenors list ───────────────────────────────────────────────────────────────
+
+
+def test_tenors_is_list(tenors):
+    assert isinstance(tenors, list)
+
+
+def test_tenors_length_is_3(tenors):
+    assert len(tenors) == 3
+
+
+def test_tenor_names_unique(tenors):
+    names = [t["tenor"] for t in tenors]
+    assert len(names) == len(set(names))
+
+
+def test_tenor_names_valid(tenors):
+    for t in tenors:
+        assert t["tenor"] in VALID_TENORS
+
+
+def test_each_tenor_has_required_keys(tenors):
+    for t in tenors:
+        assert TENOR_KEYS.issubset(t.keys())
+
+
+def test_oi_usd_positive(tenors):
+    for t in tenors:
+        assert t["oi_usd"] > 0
+
+
+def test_oi_pct_in_range(tenors):
+    for t in tenors:
+        assert 0.0 <= t["oi_pct"] <= 100.0
+
+
+def test_tenor_oi_pct_sum_to_100(tenors):
+    total = sum(t["oi_pct"] for t in tenors)
+    assert abs(total - 100.0) < 0.01
+
+
+def test_basis_annualized_is_float(tenors):
+    for t in tenors:
+        assert isinstance(t["basis_annualized"], float)
+
+
+def test_perp_days_to_expiry_is_zero(perp_tenor):
+    assert perp_tenor["days_to_expiry"] == 0
+
+
+def test_quarterly_days_to_expiry_positive(qtr_tenor):
+    assert qtr_tenor["days_to_expiry"] > 0
+
+
+def test_bi_quarterly_days_to_expiry_positive(biqtr_tenor):
+    assert biqtr_tenor["days_to_expiry"] > 0
+
+
+def test_quarterly_dte_less_than_bi_quarterly_dte(qtr_tenor, biqtr_tenor):
+    assert qtr_tenor["days_to_expiry"] < biqtr_tenor["days_to_expiry"]
+
+
+def test_perp_tenor_oi_usd_is_float(perp_tenor):
+    assert isinstance(perp_tenor["oi_usd"], float)
+
+
+def test_qtr_tenor_oi_usd_is_float(qtr_tenor):
+    assert isinstance(qtr_tenor["oi_usd"], float)
+
+
+def test_biqtr_tenor_oi_usd_is_float(biqtr_tenor):
+    assert isinstance(biqtr_tenor["oi_usd"], float)
+
+
+def test_all_oi_usd_positive(perp_tenor, qtr_tenor, biqtr_tenor):
+    assert perp_tenor["oi_usd"] > 0
+    assert qtr_tenor["oi_usd"] > 0
+    assert biqtr_tenor["oi_usd"] > 0
+
+
+# ── contango_backwardation ────────────────────────────────────────────────────
+
+
+def test_contango_backwardation_is_str(result):
+    assert isinstance(result["contango_backwardation"], str)
+
+
+def test_contango_backwardation_valid(result):
+    assert result["contango_backwardation"] in VALID_CB
+
+
+# ── roll_cost_bps ─────────────────────────────────────────────────────────────
+
+
+def test_roll_cost_bps_is_float(result):
+    assert isinstance(result["roll_cost_bps"], float)
+
+
+# ── symbol ────────────────────────────────────────────────────────────────────
+
+
+def test_symbol_is_str(result):
+    assert isinstance(result["symbol"], str)
+
+
+def test_symbol_non_empty(result):
+    assert len(result["symbol"]) > 0
+
+
+# ── timestamp ─────────────────────────────────────────────────────────────────
+
+
+def test_timestamp_is_str(result):
+    assert isinstance(result["timestamp"], str)
+
+
+def test_timestamp_non_empty(result):
+    assert len(result["timestamp"]) > 0
+
+
+# ── structure_health ──────────────────────────────────────────────────────────
+
+
+def test_structure_health_is_str(result):
+    assert isinstance(result["structure_health"], str)
+
+
+def test_structure_health_valid(result):
+    assert result["structure_health"] in VALID_HEALTH
+
+
+# ── Determinism ───────────────────────────────────────────────────────────────
+
+
+def test_deterministic_same_keys(result, result2):
+    assert result.keys() == result2.keys()
+
+
+def test_deterministic_oi_distribution(result, result2):
+    assert result["oi_distribution"] == result2["oi_distribution"]
+
+
+def test_deterministic_contango_backwardation(result, result2):
+    assert result["contango_backwardation"] == result2["contango_backwardation"]
+
+
+def test_deterministic_roll_cost_bps(result, result2):
+    assert result["roll_cost_bps"] == result2["roll_cost_bps"]
+
+
+def test_deterministic_structure_health(result, result2):
+    assert result["structure_health"] == result2["structure_health"]
+
+
+def test_deterministic_tenors_length(result, result2):
+    assert len(result["tenors"]) == len(result2["tenors"])
+
+
+def test_deterministic_tenor_names(result, result2):
+    names1 = [t["tenor"] for t in result["tenors"]]
+    names2 = [t["tenor"] for t in result2["tenors"]]
+    assert names1 == names2
+
+
+def test_deterministic_oi_usd_values(result, result2):
+    for t1, t2 in zip(result["tenors"], result2["tenors"]):
+        assert t1["oi_usd"] == t2["oi_usd"]
+
+
+def test_deterministic_basis_values(result, result2):
+    for t1, t2 in zip(result["tenors"], result2["tenors"]):
+        assert t1["basis_annualized"] == t2["basis_annualized"]
+
+
+def test_deterministic_symbol(result, result2):
+    assert result["symbol"] == result2["symbol"]

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2604,6 +2604,8 @@ async function refresh() {
     await Promise.all([safe(refreshSocialSentimentMomentum)]);
     // Batch 42: miner flow signals (Wave 25)
     await Promise.all([safe(fetchMinerFlowSignals)]);
+    // Batch 42: derivatives term structure (Wave 25)
+    await Promise.all([safe(renderDerivativesTermStructure)]);
   } finally {
     _refreshRunning = false;
   }
@@ -5743,6 +5745,53 @@ function renderMinerFlowSignals(data) {
       <span>cap risk: <b style="color:${riskCol}">${risk}</b></span>
     </div>
     <div style="font-size:10px;color:var(--muted)">forecast (7d): <b>${forecastStr}</b> BTC/day</div>`;
+}
+
+// ── Derivatives Term Structure ────────────────────────────────────────────────
+async function renderDerivativesTermStructure() {
+  const el    = document.getElementById('derivatives-term-structure-content');
+  const badge = document.getElementById('derivatives-term-structure-badge');
+  if (!el) return;
+  const data = await apiFetch('/derivatives-term-structure');
+  if (!data) { el.textContent = 'No data'; return; }
+
+  const cb        = data.contango_backwardation || 'flat';
+  const health    = data.structure_health || 'normal';
+  const rollCost  = data.roll_cost_bps ?? 0;
+  const oidist    = data.oi_distribution || {};
+  const tenors    = data.tenors || [];
+
+  const cbCls = cb === 'contango' ? 'badge-green' : cb === 'backwardation' ? 'badge-red' : 'badge-blue';
+  if (badge) {
+    badge.textContent = cb.toUpperCase();
+    badge.className   = `card-badge ${cbCls}`;
+    badge.style.display = '';
+  }
+
+  const tenorRows = tenors.map(t => {
+    const basisCol = t.basis_annualized > 0 ? 'var(--green)' : t.basis_annualized < 0 ? 'var(--red)' : 'var(--muted)';
+    const dte = t.days_to_expiry === 0 ? 'perp' : `${t.days_to_expiry}d`;
+    return `<div style="display:flex;gap:8px;margin-bottom:2px">
+      <span style="width:90px;color:var(--muted)">${t.tenor.replace('_',' ')}</span>
+      <span style="width:60px">${dte}</span>
+      <span style="width:80px">OI: <b>$${(t.oi_usd/1e6).toFixed(1)}M</b></span>
+      <span style="width:70px"><b>${t.oi_pct.toFixed(1)}%</b></span>
+      <span>basis: <b style="color:${basisCol}">${t.basis_annualized >= 0 ? '+' : ''}${t.basis_annualized.toFixed(2)}%</b></span>
+    </div>`;
+  }).join('');
+
+  const healthCol = health === 'healthy' ? 'var(--green)' : health === 'inverted' ? 'var(--red)' : 'var(--muted)';
+  const rcCol = rollCost >= 0 ? 'var(--green)' : 'var(--red)';
+
+  el.innerHTML = `
+    <div style="font-size:10px;color:var(--muted);margin-bottom:6px;display:flex;gap:12px;flex-wrap:wrap">
+      <span>structure: <b style="color:${healthCol}">${health}</b></span>
+      <span>roll cost: <b style="color:${rcCol}">${rollCost >= 0 ? '+' : ''}${rollCost.toFixed(1)} bps</b></span>
+      <span>perp: <b>${(oidist.perpetual||0).toFixed(1)}%</b></span>
+      <span>qtr: <b>${(oidist.quarterly||0).toFixed(1)}%</b></span>
+      <span>bi-qtr: <b>${(oidist.bi_quarterly||0).toFixed(1)}%</b></span>
+    </div>
+    <div style="font-size:10px">${tenorRows}</div>`;
 }
 
 // ── Bootstrap on Load ──────────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1012,6 +1012,15 @@
     <div id="validator-activity-content" style="font-size:11px;">Loading…</div>
   </section>
 
+  <section class="card" id="derivatives-term-structure-card">
+    <div class="card-header">
+      <span class="card-title">Derivatives Term Structure</span>
+      <span id="derivatives-term-structure-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">OI distribution · basis by tenor · contango/backwardation · roll cost</span>
+    </div>
+    <div id="derivatives-term-structure-content" style="font-size:11px;">Loading…</div>
+  </section>
+
   <section class="card" id="card-leverage-heatmap">
     <div class="card-header">
       <span class="card-title">Leverage Heatmap</span>


### PR DESCRIPTION
## Summary
- Adds `compute_derivatives_term_structure()` to `backend/metrics.py` with deterministic seeded random (seed 20260322)
- Returns: `oi_distribution` (perp/quarterly/bi-quarterly % of total OI), `tenors` list with basis annualized + days-to-expiry per tenor, `contango_backwardation` indicator, `roll_cost_bps`, `structure_health`
- Adds `/api/derivatives-term-structure` endpoint to `backend/api.py`
- Adds `derivatives-term-structure-card` to `frontend/index.html` and `renderDerivativesTermStructure()` to `frontend/app.js` (Batch 42 in refresh cycle)
- 58 tests in `backend/tests/test_derivatives_term_structure.py` (all passing)

## Test plan
- [x] 58 unit tests covering: return type, all required keys, OI distribution sums to 100, tenor list length/uniqueness, days-to-expiry ordering (quarterly < bi-quarterly), basis is float, contango_backwardation/structure_health valid enums, roll_cost_bps is float, full determinism across double-call
- [x] Full backend suite: 913 passed

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)