### PR TITLE
fix: restore volume profile & aggressor charts, guard correlations empty matrix

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -342,15 +342,32 @@ function initAggressorChart() {
     grid: { color: 'rgba(255,255,255,0.04)' },
   };
   opts.plugins.tooltip.callbacks = {
+    title: ctx => `${ctx[0]?.label ?? ''}`,
     label: ctx => ` ${ctx.dataset.label}: ${ctx.raw.toFixed(1)}%`,
   };
-aggressorChart = new Chart(canvas, {
+  aggressorChart = new Chart(canvas, {
     type: 'bar',
     data: {
       labels: [],
       datasets: [
-{ label: 'Buy',  data: [], backgroundColor: [], borderWidth: 0, stack: 'vp' },
-        { label: 'Sell', data: [], backgroundColor: [], borderWidth: 0, stack: 'vp' },
+        { label: 'Buy',  data: [], backgroundColor: 'rgba(0,224,130,0.7)',  borderWidth: 0, stack: 'ag' },
+        { label: 'Sell', data: [], backgroundColor: 'rgba(255,77,79,0.7)',  borderWidth: 0, stack: 'ag' },
+      ],
+    },
+    options: opts,
+  });
+}
+
+function initVolumeProfileChart() {
+  const canvas = document.getElementById('volume-profile-canvas');
+  if (!canvas || !window.Chart) return;
+  volumeProfileChart = new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels: [],
+      datasets: [
+        { label: 'Buy',  data: [], backgroundColor: 'rgba(0,224,130,0.6)',  borderWidth: 0, stack: 'vp' },
+        { label: 'Sell', data: [], backgroundColor: 'rgba(255,77,79,0.6)',  borderWidth: 0, stack: 'vp' },
       ],
     },
     options: {
@@ -382,6 +399,54 @@ aggressorChart = new Chart(canvas, {
         },
         y: {
           ticks: { color: '#6b7280', font: { size: 8 }, maxTicksLimit: 14 },
+          grid: { color: 'rgba(255,255,255,0.04)' },
+        },
+      },
+    },
+  });
+}
+
+function initAdaptiveVpChart() {
+  const canvas = document.getElementById('adaptive-vp-canvas');
+  if (!canvas || !window.Chart) return;
+  adaptiveVpChart = new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels: [],
+      datasets: [
+        { label: 'Buy',  data: [], backgroundColor: 'rgba(0,224,130,0.55)',  borderWidth: 0, stack: 'avp' },
+        { label: 'Sell', data: [], backgroundColor: 'rgba(255,77,79,0.55)',  borderWidth: 0, stack: 'avp' },
+      ],
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      indexAxis: 'y',
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+          backgroundColor: '#1c2030',
+          titleColor: '#6b7280',
+          bodyColor: '#e2e8f0',
+          borderColor: 'rgba(255,255,255,0.08)',
+          borderWidth: 1,
+          callbacks: {
+            title: ctx => `Price: ${ctx[0]?.label ?? ''}`,
+            label: ctx => ` ${ctx.dataset.label}: ${fmtK(ctx.raw)}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          stacked: true,
+          ticks: { color: '#6b7280', font: { size: 9 }, callback: v => fmtK(v) },
+          grid: { color: 'rgba(255,255,255,0.04)' },
+        },
+        y: {
+          ticks: { color: '#6b7280', font: { size: 8 }, maxTicksLimit: 16 },
           grid: { color: 'rgba(255,255,255,0.04)' },
         },
       },
@@ -473,12 +538,9 @@ function resetCharts() {
   clearChart(cvdChart);
   clearChart(fundingChart);
   clearChart(spreadChart);
-clearChart(aggressorChart);
-  clearChart(volumeProfileChart);
-  clearChart(regimeTimelineChart);
-
   clearChart(aggressorChart);
   clearChart(volumeProfileChart);
+  clearChart(adaptiveVpChart);
   clearChart(regimeTimelineChart);
 
   document.getElementById('trade-tape').innerHTML = '';
@@ -1383,7 +1445,7 @@ async function renderCorrelations() {
   const el = document.getElementById('correlations-content');
   if (!el) return;
 
-  if (!data?.matrix) {
+  if (!data?.matrix || Object.keys(data.matrix).length === 0) {
     el.innerHTML = '<div class="text-muted" style="font-size:11px;">No data available</div>';
     return;
   }
@@ -4080,9 +4142,9 @@ async function init() {
   safeInit(initFundingChart);
   safeInit(initSpreadChart);
   safeInit(initAggressorChart);
-  try { if (typeof initVolumeProfileChart === 'function') safeInit(initVolumeProfileChart); } catch(e) { console.warn('initVolumeProfileChart not defined'); }
+  safeInit(initVolumeProfileChart);
+  safeInit(initAdaptiveVpChart);
   try { if (typeof initRegimeTimelineChart === 'function') safeInit(initRegimeTimelineChart); } catch(e) { console.warn('initRegimeTimelineChart not defined'); }
-  try { if (typeof initAdaptiveVpChart === 'function') safeInit(initAdaptiveVpChart); } catch(e) { console.warn('initAdaptiveVpChart not defined'); }
   connectAlerts();
 
   // After 35s replace any still-Loading cards with Error badge

--- a/tests/test_chart_init_fixes.py
+++ b/tests/test_chart_init_fixes.py
@@ -1,0 +1,166 @@
+"""
+Tests for chart initialization fixes (issue #166):
+  - Volume Profile chart: initVolumeProfileChart must exist and target correct canvas
+  - Adaptive VP chart: initAdaptiveVpChart must exist and target correct canvas
+  - Aggressor chart: initAggressorChart must use vertical bars (not indexAxis:'y')
+  - Correlations: renderCorrelations must guard against empty matrix objects
+"""
+import os
+import re
+
+_HERE = os.path.dirname(__file__)
+_ROOT = os.path.join(_HERE, "..")
+_JS   = os.path.join(_ROOT, "frontend", "app.js")
+_HTML = os.path.join(_ROOT, "frontend", "index.html")
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+class TestVolumeProfileChartInit:
+    def test_init_function_defined(self):
+        js = _read(_JS)
+        assert "function initVolumeProfileChart(" in js
+
+    def test_targets_volume_profile_canvas(self):
+        js = _read(_JS)
+        # Extract function body
+        m = re.search(
+            r'function initVolumeProfileChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m, "initVolumeProfileChart not found"
+        body = m.group(1)
+        assert "volume-profile-canvas" in body
+
+    def test_assigns_to_volume_profile_chart_var(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initVolumeProfileChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        assert "volumeProfileChart" in body
+
+    def test_uses_horizontal_bars(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initVolumeProfileChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        assert "indexAxis" in body and "'y'" in body
+
+    def test_canvas_exists_in_html(self):
+        html = _read(_HTML)
+        assert 'id="volume-profile-canvas"' in html
+
+    def test_init_called_in_init_function(self):
+        js = _read(_JS)
+        assert "safeInit(initVolumeProfileChart)" in js
+
+
+class TestAdaptiveVpChartInit:
+    def test_init_function_defined(self):
+        js = _read(_JS)
+        assert "function initAdaptiveVpChart(" in js
+
+    def test_targets_adaptive_vp_canvas(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAdaptiveVpChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m, "initAdaptiveVpChart not found"
+        body = m.group(1)
+        assert "adaptive-vp-canvas" in body
+
+    def test_assigns_to_adaptive_vp_chart_var(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAdaptiveVpChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        assert "adaptiveVpChart" in body
+
+
+class TestAggressorChartInit:
+    def test_init_function_defined(self):
+        js = _read(_JS)
+        assert "function initAggressorChart(" in js
+
+    def test_targets_aggressor_ratio_canvas(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAggressorChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m, "initAggressorChart not found"
+        body = m.group(1)
+        assert "aggressor-ratio-canvas" in body
+
+    def test_does_not_use_horizontal_index_axis(self):
+        """Aggressor chart is a time-series (vertical bars), not horizontal."""
+        js = _read(_JS)
+        m = re.search(
+            r'function initAggressorChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        # indexAxis:'y' would make it horizontal — wrong for time series
+        assert "indexAxis" not in body or "'y'" not in body
+
+    def test_buy_dataset_has_green_color(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAggressorChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        # Should have a non-empty green background for Buy
+        assert "0,224,130" in body  # green rgba
+
+    def test_sell_dataset_has_red_color(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAggressorChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        # Should have a non-empty red background for Sell
+        assert "255,77,79" in body  # red rgba
+
+    def test_uses_opts_from_chart_defaults(self):
+        js = _read(_JS)
+        m = re.search(
+            r'function initAggressorChart\(\)(.*?)^}',
+            js, re.DOTALL | re.MULTILINE
+        )
+        assert m
+        body = m.group(1)
+        # Should use the shared opts object
+        assert "_chartDefaults" in body
+        assert "options: opts" in body
+
+
+class TestCorrelationsEmptyMatrix:
+    def test_empty_matrix_guard_present(self):
+        """renderCorrelations must check for empty matrix object, not just falsy."""
+        js = _read(_JS)
+        # Should check Object.keys length for empty matrix
+        assert "Object.keys(data.matrix).length === 0" in js
+
+    def test_guard_includes_falsy_check(self):
+        """Should also guard against null/undefined matrix."""
+        js = _read(_JS)
+        # Check the combined guard pattern
+        assert "!data?.matrix || Object.keys(data.matrix).length === 0" in js


### PR DESCRIPTION
## Summary

Fixes three broken/empty charts in the dashboard (issue #166):

- **Volume Profile chart** was never rendering — `initVolumeProfileChart()` function didn't exist, so `volumeProfileChart` was always `null` and `renderVolumeProfile()` bailed early. Added `initVolumeProfileChart()` (horizontal stacked bar on `volume-profile-canvas`) and also `initAdaptiveVpChart()` for the adaptive VP card.

- **Aggressor Ratio chart** had copy-paste bugs from volume profile code: `indexAxis:'y'` made it horizontal (wrong for a time-series), tooltip callbacks said "Price:" and used `fmtK()`, and `backgroundColor:[]` meant bars were invisible. Rewrote to use vertical stacked bars with green/red fills via `_chartDefaults`.

- **Correlations chart** showed a blank table when the backend returned `matrix: {}` (empty object) — because `{}` is truthy in JS, the `!data?.matrix` guard didn't catch it. Added `Object.keys(data.matrix).length === 0` check.

Also removed duplicate `clearChart()` calls in `resetCharts()` and added `adaptiveVpChart` to the reset sequence.

## Test plan

- [ ] All 17 new tests in `tests/test_chart_init_fixes.py` pass (verifies function existence, canvas targets, colors, empty-matrix guard)
- [ ] Full test suite: `python3 -m pytest tests/ -q --ignore=tests/test_integration*.py --ignore=tests/test_restart_recovery.py` — 4130+ passed
- [ ] Visual verification at http://94.130.65.86:8765/ — all three charts render with real data

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)