### PR TITLE
feat: aggressor imbalance streak counter card

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -13273,14 +13273,14 @@ async def compute_liquidation_cascade_risk() -> dict:
     # ── Leverage concentration (fractions summing to 1.0) ────────────────────
     _lc_raw = [_rng.random() for _ in range(4)]
     _lc_total = sum(_lc_raw)
-    _f2x  = round(_lc_raw[0] / _lc_total, 4)
-    _f5x  = round(_lc_raw[1] / _lc_total, 4)
+    _f2x = round(_lc_raw[0] / _lc_total, 4)
+    _f5x = round(_lc_raw[1] / _lc_total, 4)
     _f10x = round(_lc_raw[2] / _lc_total, 4)
     _f20x = round(1.0 - _f2x - _f5x - _f10x, 4)
     leverage_concentration: dict = {
-        "2x":   _f2x,
-        "5x":   _f5x,
-        "10x":  _f10x,
+        "2x": _f2x,
+        "5x": _f5x,
+        "10x": _f10x,
         "20x+": _f20x,
     }
 
@@ -13313,9 +13313,7 @@ async def compute_liquidation_cascade_risk() -> dict:
     _days_offset = 0
     for _ in range(10):
         _days_offset += _rng.randint(15, 45)
-        _cascade_date = (
-            _base_date - _dt_lcr.timedelta(days=_days_offset)
-        ).isoformat()
+        _cascade_date = (_base_date - _dt_lcr.timedelta(days=_days_offset)).isoformat()
         _drop_pct = round(_rng.uniform(5.0, 35.0), 2)
         _liquidated_usd = int(_rng.uniform(50_000_000.0, 1_000_000_000.0))
         historical_cascades.append(
@@ -13510,6 +13508,5 @@ async def compute_stablecoin_dominance_signal() -> dict:
         "signal_strength": signal_strength,
         "breakdown": breakdown,
         "historical_dominance": historical_dominance,
-
         "timestamp": timestamp,
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -244,6 +244,18 @@
     </div>
   </section>
 
+  <!-- Aggressor Streak -->
+  <section class="card" id="card-aggressor-streak">
+    <div class="card-header">
+      <span class="card-title">Aggressor Streak</span>
+      <span id="aggressor-streak-badge" class="card-badge" style="display:none"></span>
+      <span class="card-meta">imbalance streak · 1m candles · 70% threshold</span>
+    </div>
+    <div id="aggressor-streak-content">
+      <div class="text-muted" style="font-size:11px;">Loading…</div>
+    </div>
+  </section>
+
   <!-- Momentum -->
   <section class="card" id="card-momentum">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- Adds the missing HTML card (`card-aggressor-streak`) to `frontend/index.html`
- Backend `compute_aggressor_imbalance_streak`, `/aggressor-streak` API endpoint, JS `renderAggressorStreak` function, and 37 TDD tests were already implemented
- The card displays: streak count, direction badge (buy/sell/alert), last 10 candle bars with buy/sell % coloring, and alert state

## Test plan
- [x] 37 unit tests in `tests/test_aggressor_streak.py` — all pass
- [x] Full test suite: 4302 passed
- [x] `black` formatting applied

Closes #168