### PR TITLE
perf: dashboard load optimization — caching, indexes, timing middleware

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -267,6 +267,7 @@ async def data_freshness():
 
 
 @router.get("/stats/summary")
+@cache_result(ttl_seconds=30)
 async def stats_summary():
     """24h aggregate stats for all symbols."""
     import aiosqlite
@@ -412,6 +413,7 @@ async def liquidations_recent(
 
 
 @router.get("/cvd/history")
+@cache_result(ttl_seconds=10)
 async def cvd_history(
     window: int = Query(default=3600, le=86400),
     symbol: Optional[str] = None,
@@ -448,6 +450,7 @@ async def volume_profile(
 
 
 @router.get("/volume-profile/adaptive")
+@cache_result(ttl_seconds=30)
 async def volume_profile_adaptive(
     bins: int = Query(default=0, ge=0, le=200),
     symbol: Optional[str] = None,
@@ -819,6 +822,7 @@ async def kalman_price_endpoint(
 
 
 @router.get("/aggressor-ratio")
+@cache_result(ttl_seconds=10)
 async def aggressor_ratio_endpoint(
     symbol: Optional[str] = None,
     window: int = Query(default=1800, ge=300, le=14400),
@@ -836,6 +840,7 @@ async def aggressor_ratio_endpoint(
 
 
 @router.get("/aggressor-streak")
+@cache_result(ttl_seconds=10)
 async def aggressor_streak_endpoint(
     symbol: Optional[str] = None,
     window: int = Query(default=1800, ge=300, le=14400),
@@ -975,6 +980,7 @@ async def cvd_momentum_endpoint(
 
 
 @router.get("/market-regime")
+@cache_result(ttl_seconds=30)
 async def market_regime_endpoint(
     symbol: Optional[str] = None,
 ):
@@ -992,6 +998,7 @@ async def market_regime_endpoint(
 
 
 @router.get("/market-regime/all")
+@cache_result(ttl_seconds=30)
 async def market_regime_all():
     """Composite regime score for all tracked symbols."""
     syms = get_symbols()
@@ -1852,6 +1859,7 @@ async def _sym_summary(sym: str) -> dict:
 
 
 @router.get("/multi-summary")
+@cache_result(ttl_seconds=15)
 async def multi_summary():
     """Quick stats for all tracked symbols — for overview bar."""
     syms = get_symbols()
@@ -1963,6 +1971,7 @@ async def trade_count_rate(
 
 
 @router.get("/tape-speed")
+@cache_result(ttl_seconds=5)
 async def tape_speed_endpoint(
     window: int = Query(default=1800, ge=60, le=7200),
     bucket: int = Query(default=60, ge=10, le=300),
@@ -2198,6 +2207,7 @@ async def momentum_table():
 
 
 @router.get("/correlations")
+@cache_result(ttl_seconds=60)
 async def price_correlations(window: int = Query(default=3600, le=86400)):
     """
     Pearson correlation matrix between all tracked symbols based on 1-min OHLCV close prices.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,16 @@
 """Entry point: FastAPI app + background collectors + pollers."""
+
 import asyncio
 import logging
 import os
 import sys
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 # Load .env — supports DOTENV_PATH env var (for Docker), fallback to ~/.lain-secrets/.env
 from dotenv import load_dotenv
+
 _dotenv_path = os.environ.get("DOTENV_PATH")
 if _dotenv_path and Path(_dotenv_path).exists():
     load_dotenv(_dotenv_path)
@@ -22,6 +25,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from cache import cache_clear
 from storage import init_db, cleanup_old_data, insert_pattern, insert_phase_snapshot
@@ -37,6 +41,19 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+async def _timing_middleware(request, call_next):
+    """Add X-Response-Time header and warn on slow (>500ms) endpoints."""
+    t0 = time.monotonic()
+    response = await call_next(request)
+    elapsed_ms = (time.monotonic() - t0) * 1000
+    response.headers["X-Response-Time"] = f"{elapsed_ms:.1f}ms"
+    if elapsed_ms > 500:
+        logger.warning(
+            "SLOW %s %s %.0fms", request.method, request.url.path, elapsed_ms
+        )
+    return response
+
+
 async def cleanup_loop():
     while True:
         await asyncio.sleep(3600)
@@ -50,10 +67,11 @@ async def cleanup_loop():
 async def pattern_detection_loop():
     """Periodically detect accumulation/distribution patterns and persist them."""
     from metrics import detect_accumulation_distribution_pattern
+
     await asyncio.sleep(60)  # warm-up: wait for data to arrive
-    _last_pattern: dict = {}   # symbol -> last persisted pattern type+ts
-    PERSIST_INTERVAL = 120     # only save if pattern changed or 2 min passed
-    DETECT_INTERVAL  = 30      # run detection every 30s
+    _last_pattern: dict = {}  # symbol -> last persisted pattern type+ts
+    PERSIST_INTERVAL = 120  # only save if pattern changed or 2 min passed
+    DETECT_INTERVAL = 30  # run detection every 30s
 
     while True:
         try:
@@ -67,7 +85,7 @@ async def pattern_detection_loop():
                     # Only persist non-balanced patterns with reasonable confidence
                     if pattern != "balanced" and confidence >= 0.35:
                         last = _last_pattern.get(sym, {})
-                        last_ts   = last.get("ts", 0)
+                        last_ts = last.get("ts", 0)
                         last_type = last.get("pattern")
                         now = result["ts"]
 
@@ -81,7 +99,9 @@ async def pattern_detection_loop():
                                 description=result.get("description", ""),
                             )
                             _last_pattern[sym] = {"pattern": pattern, "ts": now}
-                            logger.info(f"Pattern persisted: {sym} {pattern} conf={confidence:.2f}")
+                            logger.info(
+                                f"Pattern persisted: {sym} {pattern} conf={confidence:.2f}"
+                            )
                 except Exception as e:
                     logger.warning(f"Pattern detection failed for {sym}: {e}")
 
@@ -96,6 +116,7 @@ async def pattern_detection_loop():
 async def phase_snapshot_loop():
     """Periodically snapshot market phase for all symbols (historical replay data)."""
     from metrics import classify_market_phase, compute_market_regime
+
     await asyncio.sleep(45)  # wait for collectors to warm up
     SNAP_INTERVAL = 30  # snapshot every 30s
 
@@ -109,7 +130,11 @@ async def phase_snapshot_loop():
                     phase = phase_result.get("phase", "unknown")
                     confidence = phase_result.get("confidence", 0.0)
                     signals = phase_result.get("signals", {})
-                    composite = regime_result.get("composite_score") if isinstance(regime_result, dict) else None
+                    composite = (
+                        regime_result.get("composite_score")
+                        if isinstance(regime_result, dict)
+                        else None
+                    )
                     await insert_phase_snapshot(
                         symbol=sym,
                         phase=phase,
@@ -166,6 +191,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+app.add_middleware(BaseHTTPMiddleware, dispatch=_timing_middleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -178,6 +204,7 @@ app.include_router(router)
 # Serve frontend
 frontend_dir = Path(__file__).parent.parent / "frontend"
 if frontend_dir.exists():
+
     @app.get("/")
     async def serve_index():
         return FileResponse(str(frontend_dir / "index.html"))
@@ -188,6 +215,7 @@ if frontend_dir.exists():
 @app.get("/health")
 async def health():
     from collectors import get_symbols
+
     return {"status": "ok", "symbols": get_symbols()}
 
 
@@ -195,6 +223,7 @@ async def health():
 async def smart_money_patterns(symbol: str = None):
     """Detect smart money behavior patterns (accumulation, distribution, absorption)."""
     from metrics import detect_smart_money_patterns
+
     return await detect_smart_money_patterns(symbol=symbol)
 
 
@@ -202,8 +231,8 @@ async def smart_money_patterns(symbol: str = None):
 async def realized_vol_surface():
     """Compute realized volatility surface: 8 symbols × 4 time windows."""
     from metrics import compute_realized_vol_surface
-    return await compute_realized_vol_surface()
 
+    return await compute_realized_vol_surface()
 
 
 @app.get("/api/aggressor-streak/{symbol}")
@@ -212,6 +241,7 @@ async def aggressor_streak(symbol: str):
     import time
     from metrics import compute_aggressor_imbalance_streak
     from storage import get_recent_trades
+
     since = time.time() - 30 * 60
     trades = await get_recent_trades(limit=10000, since=since, symbol=symbol)
     return compute_aggressor_imbalance_streak(trades)
@@ -220,11 +250,13 @@ async def aggressor_streak(symbol: str):
 @app.get("/api/cross-market-correlation")
 async def cross_market_correlation():
     from metrics import compute_cross_market_correlation
+
     return await compute_cross_market_correlation()
 
 
 if __name__ == "__main__":
     import uvicorn
+
     port = int(os.getenv("PORT", "8000"))
     host = os.getenv("HOST", "0.0.0.0")
     uvicorn.run("main:app", host=host, port=port, reload=False)

--- a/backend/scripts/perf_benchmark.py
+++ b/backend/scripts/perf_benchmark.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+perf_benchmark.py — Simple HTTP timing benchmark for svc-dash endpoints.
+
+Usage (against running backend):
+    python3 backend/scripts/perf_benchmark.py [--host http://localhost:8766] [--symbol BANANAS31USDT]
+
+Prints per-endpoint latency (cold + warm/cached) and flags anything >500ms.
+Exit code 1 if any cold request exceeds 2000ms (acceptance criterion).
+"""
+
+import argparse
+import asyncio
+import sys
+import time
+
+try:
+    import httpx
+except ImportError:
+    print("httpx required: pip install httpx")
+    sys.exit(1)
+
+# Endpoints to benchmark, with optional query params
+ENDPOINTS = [
+    "/api/symbols",
+    "/api/health",
+    "/api/stats/summary",
+    "/api/freshness",
+    "/api/cvd/history",
+    "/api/volume-profile",
+    "/api/volume-profile/adaptive",
+    "/api/oi/history",
+    "/api/funding/history",
+    "/api/liquidations/recent",
+    "/api/aggressor-ratio",
+    "/api/aggressor-streak",
+    "/api/tape-speed",
+    "/api/tape-speed-tps",
+    "/api/correlations",
+    "/api/correlations/heatmap",
+    "/api/market-regime",
+    "/api/market-regime/all",
+    "/api/multi-summary",
+    "/api/ohlcv",
+    "/api/trades/recent",
+    "/api/orderbook/latest",
+    "/api/market-depth",
+    "/api/oi-spike",
+    "/api/funding-momentum",
+    "/api/vwap-deviation",
+]
+
+SLOW_WARN_MS = 500
+SLOW_FAIL_MS = 2000
+
+
+async def bench(host: str, symbol: str) -> bool:
+    """Run benchmark. Returns True if all cold requests pass the 2s target."""
+    params = f"?symbol={symbol}"
+    results = []
+
+    async with httpx.AsyncClient(base_url=host, timeout=30) as client:
+        for endpoint in ENDPOINTS:
+            url = endpoint + params
+            times = []
+            status = None
+            for i in range(2):  # 2 runs: cold + warm
+                t0 = time.monotonic()
+                try:
+                    r = await client.get(url)
+                    elapsed_ms = (time.monotonic() - t0) * 1000
+                    status = r.status_code
+                    # Prefer server-reported time if available
+                    if "x-response-time" in r.headers:
+                        srv = r.headers["x-response-time"]
+                        if srv.endswith("ms"):
+                            elapsed_ms = float(srv[:-2])
+                except Exception as e:
+                    elapsed_ms = (time.monotonic() - t0) * 1000
+                    status = f"ERR:{e}"
+                times.append(elapsed_ms)
+                await asyncio.sleep(0.05)  # brief pause between calls
+
+            cold, warm = times[0], times[1]
+            results.append((endpoint, cold, warm, status))
+
+    # Print table
+    header = f"{'Endpoint':<45}  {'Cold':>8}  {'Warm':>8}  {'Status':>6}"
+    print(header)
+    print("-" * len(header))
+
+    failed = False
+    for endpoint, cold, warm, status in results:
+        cold_flag = " ⚠️ SLOW" if cold > SLOW_WARN_MS else ""
+        warm_flag = " ⚠️ SLOW" if warm > SLOW_WARN_MS else ""
+        if cold > SLOW_FAIL_MS:
+            cold_flag = " ❌ >2s"
+            failed = True
+        print(
+            f"{endpoint:<45}  {cold:>7.0f}ms  {warm:>7.0f}ms  {status!s:>6}"
+            f"{cold_flag}{warm_flag}"
+        )
+
+    print()
+    slow = [(ep, c) for ep, c, _, _ in results if c > SLOW_WARN_MS]
+    if slow:
+        print(f"Slow endpoints (>{SLOW_WARN_MS}ms cold):")
+        for ep, ms in sorted(slow, key=lambda x: -x[1]):
+            print(f"  {ms:>7.0f}ms  {ep}")
+    else:
+        print("All endpoints responded within 500ms on cold call. ✓")
+
+    return not failed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="svc-dash endpoint latency benchmark")
+    parser.add_argument(
+        "--host", default="http://localhost:8766", help="Backend base URL"
+    )
+    parser.add_argument(
+        "--symbol", default="BANANAS31USDT", help="Symbol for query params"
+    )
+    args = parser.parse_args()
+
+    print(f"Benchmarking {args.host} (symbol={args.symbol})\n")
+    ok = asyncio.run(bench(args.host, args.symbol))
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -1,4 +1,5 @@
 """SQLite storage layer using aiosqlite — multi-symbol."""
+
 import aiosqlite
 import asyncio
 import json
@@ -10,19 +11,24 @@ DB_PATH = os.getenv("DB_PATH", "data/bananas31.db")
 
 from contextlib import asynccontextmanager
 
+
 @asynccontextmanager
 async def open_db(path=None):
-    """Open SQLite with WAL + busy_timeout=5000ms."""
+    """Open SQLite with WAL + optimised read/write PRAGMAs."""
     p = path or DB_PATH
     import os
-    os.makedirs(os.path.dirname(p) or '.', exist_ok=True)
+
+    os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
     async with aiosqlite.connect(p) as db:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("PRAGMA synchronous=NORMAL")
         await db.execute("PRAGMA busy_timeout=5000")
+        # 32 MB in-memory page cache (default is ~2 MB) — reduces disk I/O
+        await db.execute("PRAGMA cache_size=-32768")
+        # Keep temp tables in memory instead of on disk
+        await db.execute("PRAGMA temp_store=MEMORY")
         yield db
-
 
 
 async def get_db() -> aiosqlite.Connection:
@@ -109,16 +115,28 @@ async def init_db():
         """)
 
         # Indexes for time-range queries
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_ob_ts ON orderbook_snapshots(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_ob_sym ON orderbook_snapshots(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ob_ts ON orderbook_snapshots(ts)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ob_sym ON orderbook_snapshots(symbol, ts)"
+        )
         await db.execute("CREATE INDEX IF NOT EXISTS idx_trades_ts ON trades(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_trades_sym ON trades(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trades_sym ON trades(symbol, ts)"
+        )
         await db.execute("CREATE INDEX IF NOT EXISTS idx_oi_ts ON open_interest(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_oi_sym ON open_interest(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_oi_sym ON open_interest(symbol, ts)"
+        )
         await db.execute("CREATE INDEX IF NOT EXISTS idx_fr_ts ON funding_rate(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_fr_sym ON funding_rate(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fr_sym ON funding_rate(symbol, ts)"
+        )
         await db.execute("CREATE INDEX IF NOT EXISTS idx_liq_ts ON liquidations(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_liq_sym ON liquidations(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_liq_sym ON liquidations(symbol, ts)"
+        )
 
         # Dedicated spread history table for faster queries / less IO
         await db.execute("""
@@ -137,8 +155,12 @@ async def init_db():
                 ask_vol REAL
             )
         """)
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_spread_ts  ON spread_history(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_spread_sym ON spread_history(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_spread_ts  ON spread_history(ts)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_spread_sym ON spread_history(symbol, ts)"
+        )
 
         await db.execute("""
             CREATE TABLE IF NOT EXISTS alert_history (
@@ -152,7 +174,9 @@ async def init_db():
             )
         """)
         await db.execute("CREATE INDEX IF NOT EXISTS idx_alert_ts ON alert_history(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_alert_sym ON alert_history(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_alert_sym ON alert_history(symbol, ts)"
+        )
 
         await db.execute("""
             CREATE TABLE IF NOT EXISTS whale_trades (
@@ -167,13 +191,54 @@ async def init_db():
             )
         """)
         await db.execute("CREATE INDEX IF NOT EXISTS idx_whale_ts ON whale_trades(ts)")
-        await db.execute("CREATE INDEX IF NOT EXISTS idx_whale_sym ON whale_trades(symbol, ts)")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whale_sym ON whale_trades(symbol, ts)"
+        )
+
+        # pattern_history — created eagerly so indexes are always present
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS pattern_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts REAL NOT NULL,
+                symbol TEXT NOT NULL,
+                pattern_type TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                signals TEXT NOT NULL,
+                description TEXT NOT NULL
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pattern_ts  ON pattern_history(ts)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pattern_sym ON pattern_history(symbol, ts)"
+        )
+
+        # phase_snapshots — created eagerly so indexes are always present
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS phase_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts REAL NOT NULL,
+                symbol TEXT NOT NULL,
+                phase TEXT NOT NULL,
+                confidence REAL,
+                composite_score REAL,
+                signals TEXT
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_phase_ts  ON phase_snapshots(ts)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_phase_sym ON phase_snapshots(symbol, ts)"
+        )
 
         await db.commit()
 
 
 async def insert_orderbook(exchange: str, symbol: str, bids: list, asks: list):
     import json
+
     ts = time.time()
     best_bid = float(bids[0][0]) if bids else None
     best_ask = float(asks[0][0]) if asks else None
@@ -182,47 +247,95 @@ async def insert_orderbook(exchange: str, symbol: str, bids: list, asks: list):
 
     bid_vol = sum(float(b[1]) for b in bids[:10])
     ask_vol = sum(float(a[1]) for a in asks[:10])
-    imbalance = (bid_vol - ask_vol) / (bid_vol + ask_vol) if (bid_vol + ask_vol) > 0 else 0
+    imbalance = (
+        (bid_vol - ask_vol) / (bid_vol + ask_vol) if (bid_vol + ask_vol) > 0 else 0
+    )
 
     spread_pct = (spread / mid_price * 100) if (spread and mid_price) else None
     spread_bps = round(spread_pct * 100, 4) if spread_pct is not None else None
 
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO orderbook_snapshots
             (ts, exchange, symbol, bids, asks, best_bid, best_ask, mid_price, spread, bid_volume, ask_volume, imbalance)
             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
-        """, (ts, exchange, symbol,
-              json.dumps(bids[:20]), json.dumps(asks[:20]),
-              best_bid, best_ask, mid_price, spread,
-              bid_vol, ask_vol, imbalance))
+        """,
+            (
+                ts,
+                exchange,
+                symbol,
+                json.dumps(bids[:20]),
+                json.dumps(asks[:20]),
+                best_bid,
+                best_ask,
+                mid_price,
+                spread,
+                bid_vol,
+                ask_vol,
+                imbalance,
+            ),
+        )
         # Also write to dedicated spread_history table for fast tracker queries
         if spread_pct is not None:
-            await db.execute("""
+            await db.execute(
+                """
                 INSERT INTO spread_history
                 (ts, symbol, exchange, spread_pct, spread_bps, spread_abs, bid, ask, mid, bid_vol, ask_vol)
                 VALUES (?,?,?,?,?,?,?,?,?,?,?)
-            """, (ts, symbol, exchange, round(spread_pct, 6), spread_bps,
-                  round(spread, 8) if spread else None,
-                  best_bid, best_ask, mid_price, bid_vol, ask_vol))
+            """,
+                (
+                    ts,
+                    symbol,
+                    exchange,
+                    round(spread_pct, 6),
+                    spread_bps,
+                    round(spread, 8) if spread else None,
+                    best_bid,
+                    best_ask,
+                    mid_price,
+                    bid_vol,
+                    ask_vol,
+                ),
+            )
         await db.commit()
 
 
 async def insert_spread(
-    symbol: str, exchange: str,
-    spread_pct: float, spread_bps: float,
+    symbol: str,
+    exchange: str,
+    spread_pct: float,
+    spread_bps: float,
     spread_abs: float = None,
-    bid: float = None, ask: float = None, mid: float = None,
-    bid_vol: float = None, ask_vol: float = None,
+    bid: float = None,
+    ask: float = None,
+    mid: float = None,
+    bid_vol: float = None,
+    ask_vol: float = None,
 ):
     """Explicit spread insert (for external callers)."""
     ts = time.time()
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO spread_history
             (ts, symbol, exchange, spread_pct, spread_bps, spread_abs, bid, ask, mid, bid_vol, ask_vol)
             VALUES (?,?,?,?,?,?,?,?,?,?,?)
-        """, (ts, symbol, exchange, spread_pct, spread_bps, spread_abs, bid, ask, mid, bid_vol, ask_vol))
+        """,
+            (
+                ts,
+                symbol,
+                exchange,
+                spread_pct,
+                spread_bps,
+                spread_abs,
+                bid,
+                ask,
+                mid,
+                bid_vol,
+                ask_vol,
+            ),
+        )
         await db.commit()
 
 
@@ -249,14 +362,18 @@ async def get_spread_history(
             return [dict(r) for r in rows]
 
 
-async def get_spread_stats(symbol: str, window: int = 1800, exchange: str = None) -> Dict:
+async def get_spread_stats(
+    symbol: str, window: int = 1800, exchange: str = None
+) -> Dict:
     """Return current, avg, max spread and alert status."""
     since = time.time() - window
-    rows = await get_spread_history(symbol=symbol, since=since, exchange=exchange, limit=5000)
+    rows = await get_spread_history(
+        symbol=symbol, since=since, exchange=exchange, limit=5000
+    )
     if not rows:
         return {"symbol": symbol, "count": 0}
     bps_vals = [r["spread_bps"] for r in rows if r["spread_bps"] is not None]
-    pct_vals  = [r["spread_pct"] for r in rows if r["spread_pct"] is not None]
+    pct_vals = [r["spread_pct"] for r in rows if r["spread_pct"] is not None]
     if not bps_vals:
         return {"symbol": symbol, "count": 0}
     current_bps = bps_vals[-1]
@@ -268,14 +385,22 @@ async def get_spread_stats(symbol: str, window: int = 1800, exchange: str = None
     alert = None
     # Alert: current > 0.5% spread OR > 2x avg
     if current_pct is not None and current_pct > 0.5:
-        alert = {"level": "high", "reason": "spread_pct_threshold",
-                 "message": f"Spread {current_pct:.4f}% exceeds 0.5% threshold",
-                 "current_pct": round(current_pct, 4), "current_bps": round(current_bps, 2)}
+        alert = {
+            "level": "high",
+            "reason": "spread_pct_threshold",
+            "message": f"Spread {current_pct:.4f}% exceeds 0.5% threshold",
+            "current_pct": round(current_pct, 4),
+            "current_bps": round(current_bps, 2),
+        }
     elif avg_bps > 0 and current_bps > avg_bps * 2:
-        alert = {"level": "medium", "reason": "spread_widening",
-                 "message": f"Spread widened: {current_bps:.1f} bps (avg {avg_bps:.1f} bps, {current_bps/avg_bps:.1f}x)",
-                 "current_bps": round(current_bps, 2), "avg_bps": round(avg_bps, 2),
-                 "ratio": round(current_bps / avg_bps, 2)}
+        alert = {
+            "level": "medium",
+            "reason": "spread_widening",
+            "message": f"Spread widened: {current_bps:.1f} bps (avg {avg_bps:.1f} bps, {current_bps/avg_bps:.1f}x)",
+            "current_bps": round(current_bps, 2),
+            "avg_bps": round(avg_bps, 2),
+            "ratio": round(current_bps / avg_bps, 2),
+        }
     latest = rows[-1]
     return {
         "symbol": symbol,
@@ -297,44 +422,69 @@ async def get_spread_stats(symbol: str, window: int = 1800, exchange: str = None
     }
 
 
-async def insert_trade(exchange: str, symbol: str, price: float, qty: float, side: str, trade_id: str = None):
+async def insert_trade(
+    exchange: str,
+    symbol: str,
+    price: float,
+    qty: float,
+    side: str,
+    trade_id: str = None,
+):
     ts = time.time()
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO trades (ts, exchange, symbol, price, qty, side, trade_id)
             VALUES (?,?,?,?,?,?,?)
-        """, (ts, exchange, symbol, price, qty, side, trade_id))
+        """,
+            (ts, exchange, symbol, price, qty, side, trade_id),
+        )
         await db.commit()
 
 
-async def insert_oi(exchange: str, symbol: str, oi_value: float, oi_contracts: float = None):
+async def insert_oi(
+    exchange: str, symbol: str, oi_value: float, oi_contracts: float = None
+):
     ts = time.time()
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO open_interest (ts, exchange, symbol, oi_value, oi_contracts)
             VALUES (?,?,?,?,?)
-        """, (ts, exchange, symbol, oi_value, oi_contracts))
+        """,
+            (ts, exchange, symbol, oi_value, oi_contracts),
+        )
         await db.commit()
 
 
-async def insert_funding(exchange: str, symbol: str, rate: float, next_ts: float = None):
+async def insert_funding(
+    exchange: str, symbol: str, rate: float, next_ts: float = None
+):
     ts = time.time()
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO funding_rate (ts, exchange, symbol, rate, next_funding_ts)
             VALUES (?,?,?,?,?)
-        """, (ts, exchange, symbol, rate, next_ts))
+        """,
+            (ts, exchange, symbol, rate, next_ts),
+        )
         await db.commit()
 
 
-async def insert_liquidation(exchange: str, symbol: str, side: str, price: float, qty: float):
+async def insert_liquidation(
+    exchange: str, symbol: str, side: str, price: float, qty: float
+):
     ts = time.time()
     value = price * qty
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO liquidations (ts, exchange, symbol, side, price, qty, value)
             VALUES (?,?,?,?,?,?,?)
-        """, (ts, exchange, symbol, side, price, qty, value))
+        """,
+            (ts, exchange, symbol, side, price, qty, value),
+        )
         await db.commit()
 
 
@@ -353,7 +503,9 @@ def _build_query(base: str, filters: list, order: str, limit: int) -> tuple:
     return base, params
 
 
-def _build_query_with_since(base: str, since: float, symbol: Optional[str], order: str, limit: int) -> tuple:
+def _build_query_with_since(
+    base: str, since: float, symbol: Optional[str], order: str, limit: int
+) -> tuple:
     params = [since]
     q = base + " WHERE ts > ?"
     if symbol:
@@ -365,9 +517,7 @@ def _build_query_with_since(base: str, since: float, symbol: Optional[str], orde
 
 
 async def get_latest_orderbook(
-    exchange: str = None,
-    symbol: str = None,
-    limit: int = 1
+    exchange: str = None, symbol: str = None, limit: int = 1
 ) -> List[Dict]:
     q = "SELECT * FROM orderbook_snapshots"
     params = []
@@ -453,7 +603,9 @@ async def get_recent_liquidations(
             return [dict(r) for r in rows]
 
 
-async def get_trades_for_volume_profile(since: float, symbol: str = None, tick_size: float = None) -> List[Dict]:
+async def get_trades_for_volume_profile(
+    since: float, symbol: str = None, tick_size: float = None
+) -> List[Dict]:
     """
     Return aggregated volume per price level for volume profile.
     tick_size controls price resolution (default: auto-detected from data).
@@ -476,6 +628,7 @@ async def get_trades_for_volume_profile(since: float, symbol: str = None, tick_s
 
         # Pick tick size as ~0.05% of avg price, rounded to a nice number
         import math
+
         magnitude = 10 ** math.floor(math.log10(avg_price * 0.0005))
         tick_size = round(avg_price * 0.0005 / magnitude) * magnitude
         tick_size = max(tick_size, 1e-8)
@@ -567,18 +720,8 @@ async def get_ohlcv(
     if symbol:
         full_params.append(symbol)
 
-    async with open_db() as db:
-        db.row_factory = aiosqlite.Row
-        # We need open/close as first/last prices — get them in a separate pass
-        async with db.execute(q, full_params) as cur:
-            rows = await cur.fetchall()
-            buckets = [dict(r) for r in rows]
-
-    if not buckets:
-        return []
-
-    # Fetch first/last price per bucket for true open/close
-    # Use window functions if SQLite supports them (3.25+), otherwise fallback
+    # Fetch first/last price per bucket for true open/close.
+    # Use window functions (SQLite 3.25+) — both queries share one connection.
     q2 = f"""
         SELECT
             CAST(ts / ? AS INTEGER) * ? AS bucket,
@@ -589,17 +732,27 @@ async def get_ohlcv(
         WHERE ts > ?{sym_filter}
         GROUP BY bucket
     """
-    try:
-        oc_params: list = [interval, interval, interval, interval, since]
-        if symbol:
-            oc_params.append(symbol)
-        async with open_db() as db:
-            db.row_factory = aiosqlite.Row
+    oc_params: list = [interval, interval, interval, interval, since]
+    if symbol:
+        oc_params.append(symbol)
+
+    async with open_db() as db:
+        db.row_factory = aiosqlite.Row
+        # Main aggregation
+        async with db.execute(q, full_params) as cur:
+            rows = await cur.fetchall()
+            buckets = [dict(r) for r in rows]
+
+        if not buckets:
+            return []
+
+        # Open/close via window functions — same connection, no extra overhead
+        try:
             async with db.execute(q2, oc_params) as cur:
                 oc_rows = await cur.fetchall()
                 oc_map = {r["bucket"]: (r["open"], r["close"]) for r in oc_rows}
-    except Exception:
-        oc_map = {}
+        except Exception:
+            oc_map = {}
 
     # Compute cumulative VWAP across all candles
     cum_pv = 0.0
@@ -610,21 +763,23 @@ async def get_ohlcv(
         o, c = oc_map.get(bucket, (b["open_price"], b["close_price"]))
         typical_price = (b["high"] + b["low"] + c) / 3.0
         vol = b["volume"] or 0
-        cum_pv  += typical_price * vol
+        cum_pv += typical_price * vol
         cum_vol += vol
         vwap = cum_pv / cum_vol if cum_vol > 0 else None
-        result.append({
-            "ts": bucket,
-            "open": o,
-            "high": b["high"],
-            "low": b["low"],
-            "close": c,
-            "volume": b["volume"],
-            "buy_volume": b["buy_volume"],
-            "sell_volume": b["sell_volume"],
-            "trade_count": b["trade_count"],
-            "vwap": round(vwap, 8) if vwap else None,
-        })
+        result.append(
+            {
+                "ts": bucket,
+                "open": o,
+                "high": b["high"],
+                "low": b["low"],
+                "close": c,
+                "volume": b["volume"],
+                "buy_volume": b["buy_volume"],
+                "sell_volume": b["sell_volume"],
+                "trade_count": b["trade_count"],
+                "vwap": round(vwap, 8) if vwap else None,
+            }
+        )
     return result
 
 
@@ -690,15 +845,21 @@ async def get_orderbook_snapshots_for_heatmap(
     return sampled
 
 
-async def insert_alert(symbol: str, alert_type: str, severity: str, description: str, data: dict = None):
+async def insert_alert(
+    symbol: str, alert_type: str, severity: str, description: str, data: dict = None
+):
     """Persist a fired alert to history."""
     import json
+
     ts = time.time()
     async with open_db() as db:
-        await db.execute("""
+        await db.execute(
+            """
             INSERT INTO alert_history (ts, symbol, alert_type, severity, description, data)
             VALUES (?,?,?,?,?,?)
-        """, (ts, symbol, alert_type, severity, description, json.dumps(data or {})))
+        """,
+            (ts, symbol, alert_type, severity, description, json.dumps(data or {})),
+        )
         await db.commit()
 
 
@@ -727,9 +888,12 @@ async def get_alert_history(
             return [dict(r) for r in rows]
 
 
-async def insert_pattern(symbol: str, pattern_type: str, confidence: float, signals: dict, description: str):
+async def insert_pattern(
+    symbol: str, pattern_type: str, confidence: float, signals: dict, description: str
+):
     """Persist a detected market pattern to history."""
     import json
+
     ts = time.time()
     async with open_db() as db:
         await db.execute("""
@@ -745,7 +909,7 @@ async def insert_pattern(symbol: str, pattern_type: str, confidence: float, sign
         """)
         await db.execute(
             "INSERT INTO pattern_history (ts, symbol, pattern_type, confidence, signals, description) VALUES (?,?,?,?,?,?)",
-            (ts, symbol, pattern_type, confidence, json.dumps(signals), description)
+            (ts, symbol, pattern_type, confidence, json.dumps(signals), description),
         )
         await db.commit()
 
@@ -758,6 +922,7 @@ async def get_pattern_history(
 ) -> List[Dict]:
     """Fetch recent pattern detections."""
     import json
+
     since = since or (time.time() - 86400)
     params: list = [since]
     q = "SELECT * FROM pattern_history WHERE ts > ?"
@@ -802,11 +967,17 @@ async def cleanup_old_data(max_age_seconds: int = 86400 * 7):
         for table in ["trades", "open_interest", "funding_rate", "liquidations"]:
             await db.execute(f"DELETE FROM {table} WHERE ts < ?", (cutoff,))
         # Keep orderbook only last 30 minutes (enough for heatmap)
-        await db.execute("DELETE FROM orderbook_snapshots WHERE ts < ?", (time.time() - 1800,))
+        await db.execute(
+            "DELETE FROM orderbook_snapshots WHERE ts < ?", (time.time() - 1800,)
+        )
         # Keep spread history 4 hours (1s resolution → ~14400 rows/symbol → manageable)
-        await db.execute("DELETE FROM spread_history WHERE ts < ?", (time.time() - 14400,))
+        await db.execute(
+            "DELETE FROM spread_history WHERE ts < ?", (time.time() - 14400,)
+        )
         # Keep alert history 30 days
-        await db.execute("DELETE FROM alert_history WHERE ts < ?", (time.time() - 86400 * 30,))
+        await db.execute(
+            "DELETE FROM alert_history WHERE ts < ?", (time.time() - 86400 * 30,)
+        )
         await db.commit()
     # Reclaim space (VACUUM requires its own connection)
     async with open_db() as db2:
@@ -814,17 +985,26 @@ async def cleanup_old_data(max_age_seconds: int = 86400 * 7):
         await db2.execute("ANALYZE")
 
 
-async def insert_whale_trade(symbol: str, price: float, qty: float, side: str, value_usd: float, exchange: str = "binance"):
+async def insert_whale_trade(
+    symbol: str,
+    price: float,
+    qty: float,
+    side: str,
+    value_usd: float,
+    exchange: str = "binance",
+):
     """Log a whale trade (value > threshold) to persistent storage."""
     async with open_db() as db:
         await db.execute(
             "INSERT INTO whale_trades (ts, symbol, price, qty, side, value_usd, exchange) VALUES (?,?,?,?,?,?,?)",
-            (time.time(), symbol, price, qty, side, value_usd, exchange)
+            (time.time(), symbol, price, qty, side, value_usd, exchange),
         )
         await db.commit()
 
 
-async def get_whale_trades(limit: int = 100, since: float = None, symbol: str = None, min_usd: float = 50000) -> list:
+async def get_whale_trades(
+    limit: int = 100, since: float = None, symbol: str = None, min_usd: float = 50000
+) -> list:
     """Fetch recent whale trades, optionally filtered by symbol and time window."""
     params = [min_usd]
     q = "SELECT * FROM whale_trades WHERE value_usd >= ?"
@@ -843,11 +1023,16 @@ async def get_whale_trades(limit: int = 100, since: float = None, symbol: str = 
             return [dict(r) for r in rows]
 
 
-async def insert_phase_snapshot(symbol: str, phase: str, confidence: float, signals: dict, composite_score: float = None):
+async def insert_phase_snapshot(
+    symbol: str,
+    phase: str,
+    confidence: float,
+    signals: dict,
+    composite_score: float = None,
+):
     """Store a periodic market phase snapshot for historical replay."""
     async with open_db() as db:
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS phase_snapshots (
+        await db.execute("""CREATE TABLE IF NOT EXISTS phase_snapshots (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 ts REAL NOT NULL,
                 symbol TEXT NOT NULL,
@@ -855,12 +1040,17 @@ async def insert_phase_snapshot(symbol: str, phase: str, confidence: float, sign
                 confidence REAL,
                 composite_score REAL,
                 signals TEXT
-            )"""
-        )
+            )""")
         await db.execute(
             "INSERT INTO phase_snapshots (ts, symbol, phase, confidence, composite_score, signals) VALUES (?,?,?,?,?,?)",
-            (time.time(), symbol, phase, confidence, composite_score,
-             json.dumps(signals) if signals else None)
+            (
+                time.time(),
+                symbol,
+                phase,
+                confidence,
+                composite_score,
+                json.dumps(signals) if signals else None,
+            ),
         )
         await db.commit()
 
@@ -874,8 +1064,7 @@ async def get_phase_snapshots(
     """Fetch phase snapshots for historical replay."""
     async with open_db() as db:
         # Ensure table exists
-        await db.execute(
-            """CREATE TABLE IF NOT EXISTS phase_snapshots (
+        await db.execute("""CREATE TABLE IF NOT EXISTS phase_snapshots (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 ts REAL NOT NULL,
                 symbol TEXT NOT NULL,
@@ -883,8 +1072,7 @@ async def get_phase_snapshots(
                 confidence REAL,
                 composite_score REAL,
                 signals TEXT
-            )"""
-        )
+            )""")
         params = []
         q = "SELECT * FROM phase_snapshots WHERE 1=1"
         if symbol:

--- a/backend/tests/test_perf_optimizations.py
+++ b/backend/tests/test_perf_optimizations.py
@@ -1,0 +1,252 @@
+"""Performance optimization tests — TDD (issue #170).
+
+Covers:
+  1. Timing middleware exports _timing_middleware and adds X-Response-Time header
+  2. DB has proper indexes on pattern_history and phase_snapshots after init_db()
+  3. SQLite open_db() applies cache_size and temp_store PRAGMAs
+  4. Expensive endpoints populate the in-memory cache on first call
+"""
+
+import os
+import sys
+import tempfile
+
+import aiosqlite
+import httpx
+import pytest
+
+os.environ.setdefault("DB_PATH", os.path.join(tempfile.mkdtemp(), "test_perf.db"))
+os.environ.setdefault("SYMBOL_BINANCE", "BANANAS31USDT")
+os.environ.setdefault("SYMBOL_BYBIT", "BANANAS31USDT")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from storage import init_db, DB_PATH  # noqa: E402
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_app():
+    """Test app: router + timing middleware imported from production main.py."""
+    from fastapi import FastAPI
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from api import router
+    from main import _timing_middleware  # fails if middleware not exported from main
+
+    app = FastAPI()
+    app.add_middleware(BaseHTTPMiddleware, dispatch=_timing_middleware)
+    app.include_router(router)
+    return app
+
+
+def _client(app=None):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app or _make_app()),
+        base_url="http://test",
+    )
+
+
+# ── 1. Timing middleware ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_timing_middleware_header_on_symbols():
+    """X-Response-Time header must be present on every response."""
+    await init_db()
+    async with _client() as c:
+        r = await c.get("/api/symbols")
+    assert r.status_code == 200
+    assert "x-response-time" in r.headers, "Missing X-Response-Time header"
+
+
+@pytest.mark.asyncio
+async def test_timing_middleware_header_on_health():
+    """X-Response-Time header must appear on /api/health."""
+    await init_db()
+    async with _client() as c:
+        r = await c.get("/api/health")
+    assert r.status_code == 200
+    assert "x-response-time" in r.headers
+
+
+@pytest.mark.asyncio
+async def test_timing_middleware_format():
+    """X-Response-Time must be formatted as '<float>ms'."""
+    await init_db()
+    async with _client() as c:
+        r = await c.get("/api/symbols")
+    val = r.headers.get("x-response-time", "")
+    assert val.endswith("ms"), f"Expected '<float>ms', got: {val!r}"
+    elapsed = float(val[:-2])
+    assert elapsed >= 0.0, f"Elapsed time must be non-negative, got {elapsed}"
+
+
+# ── 2. DB indexes ─────────────────────────────────────────────────────────────
+
+
+async def _index_names(table: str) -> list:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?",
+            (table,),
+        ) as cur:
+            rows = await cur.fetchall()
+    return [r[0] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_pattern_history_index():
+    """init_db must create an index on pattern_history(symbol, ts)."""
+    await init_db()
+    names = await _index_names("pattern_history")
+    assert names, f"No indexes on pattern_history; found: {names}"
+    assert any(
+        "sym" in n.lower() or "pattern" in n.lower() for n in names
+    ), f"Expected a symbol-based index on pattern_history; found: {names}"
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_phase_snapshots_index():
+    """init_db must create an index on phase_snapshots(symbol, ts)."""
+    await init_db()
+    names = await _index_names("phase_snapshots")
+    assert names, f"No indexes on phase_snapshots; found: {names}"
+    assert any(
+        "sym" in n.lower() or "phase" in n.lower() or "snap" in n.lower() for n in names
+    ), f"Expected a symbol-based index on phase_snapshots; found: {names}"
+
+
+@pytest.mark.asyncio
+async def test_core_tables_have_indexes():
+    """Core tables must have (symbol, ts) indexes."""
+    await init_db()
+    for table in ("trades", "open_interest", "funding_rate", "liquidations"):
+        names = await _index_names(table)
+        assert names, f"No indexes on {table}"
+
+
+# ── 3. SQLite PRAGMAs ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_open_db_uses_wal_mode():
+    """open_db() must use WAL journal mode."""
+    from storage import open_db
+
+    async with open_db() as db:
+        async with db.execute("PRAGMA journal_mode") as cur:
+            row = await cur.fetchone()
+    assert row[0].lower() == "wal"
+
+
+@pytest.mark.asyncio
+async def test_open_db_sets_large_cache():
+    """open_db() must set cache_size significantly above the SQLite default (−2000)."""
+    from storage import open_db
+
+    async with open_db() as db:
+        async with db.execute("PRAGMA cache_size") as cur:
+            row = await cur.fetchone()
+    # Default is −2000 (2 MB). We require at least −8000 (8 MB).
+    assert (
+        abs(row[0]) >= 8000
+    ), f"cache_size {row[0]} is not much larger than default −2000"
+
+
+@pytest.mark.asyncio
+async def test_open_db_sets_temp_store_memory():
+    """open_db() must configure temp_store=MEMORY (value=2) for faster temp tables."""
+    from storage import open_db
+
+    async with open_db() as db:
+        async with db.execute("PRAGMA temp_store") as cur:
+            row = await cur.fetchone()
+    # 0=default, 1=FILE, 2=MEMORY
+    assert row[0] == 2, f"temp_store expected 2 (MEMORY), got {row[0]}"
+
+
+# ── 4. Cache population ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_summary_populates_cache():
+    """/api/stats/summary must populate the cache so repeated calls are cheap."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/stats/summary")
+    assert (
+        cache_size() > 0
+    ), "/api/stats/summary did not populate cache — @cache_result decorator missing?"
+
+
+@pytest.mark.asyncio
+async def test_correlations_populates_cache():
+    """/api/correlations must populate cache on first call."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/correlations")
+    assert (
+        cache_size() > 0
+    ), "/api/correlations did not populate cache — @cache_result decorator missing?"
+
+
+@pytest.mark.asyncio
+async def test_market_regime_populates_cache():
+    """/api/market-regime must populate cache on first call."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/market-regime?symbol=BANANAS31USDT")
+    assert (
+        cache_size() > 0
+    ), "/api/market-regime did not populate cache — @cache_result decorator missing?"
+
+
+@pytest.mark.asyncio
+async def test_cvd_history_populates_cache():
+    """/api/cvd/history must populate cache on first call."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/cvd/history?symbol=BANANAS31USDT")
+    assert (
+        cache_size() > 0
+    ), "/api/cvd/history did not populate cache — @cache_result decorator missing?"
+
+
+@pytest.mark.asyncio
+async def test_multi_summary_populates_cache():
+    """/api/multi-summary must populate cache on first call."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/multi-summary")
+    assert (
+        cache_size() > 0
+    ), "/api/multi-summary did not populate cache — @cache_result decorator missing?"
+
+
+@pytest.mark.asyncio
+async def test_tape_speed_populates_cache():
+    """/api/tape-speed must populate cache on first call."""
+    from cache import cache_clear, cache_size
+
+    await init_db()
+    cache_clear()
+    async with _client() as c:
+        await c.get("/api/tape-speed?symbol=BANANAS31USDT")
+    assert (
+        cache_size() > 0
+    ), "/api/tape-speed did not populate cache — @cache_result decorator missing?"


### PR DESCRIPTION
## Summary

Fixes #170 — dashboard loading too slow ("данные грузятся 5 лет").

### Root causes identified
- **No caching** on 10+ expensive endpoints (each frontend poll = full DB scan)
- **Missing indexes** on `pattern_history` and `phase_snapshots` (growing tables, no sym/ts index)
- **Suboptimal SQLite PRAGMAs**: default 2MB page cache, temp tables on disk
- **`get_ohlcv` opened 2 separate DB connections** per call (double PRAGMA setup overhead)
- **No observability**: impossible to identify slow endpoints without timing logs

### Changes

**Caching (biggest impact)** — adds `@cache_result` to 10 previously uncached expensive endpoints:
| Endpoint | TTL | Why expensive |
|---|---|---|
| `/api/stats/summary` | 30s | 5 aggregate queries on 24h of trades |
| `/api/cvd/history` | 10s | All trades for 1h window fetched raw |
| `/api/volume-profile/adaptive` | 30s | Full trades table scan |
| `/api/aggressor-ratio` | 10s | 30min of trade data |
| `/api/aggressor-streak` | 10s | 20k trade limit fetch |
| `/api/market-regime` | 30s | Calls v1+v2, each with 6 sub-queries |
| `/api/market-regime/all` | 30s | market-regime × all symbols |
| `/api/multi-summary` | 15s | 6 parallel queries per symbol × N symbols |
| `/api/tape-speed` | 5s | 30min of trade data |
| `/api/correlations` | 60s | `get_ohlcv` × all symbols |

**DB indexes** — `pattern_history(symbol, ts)` and `phase_snapshots(symbol, ts)` now created eagerly in `init_db()` with proper indexes (previously lazy-created with no indexes)

**SQLite PRAGMAs** in `open_db()`:
- `cache_size=-32768` → 32MB in-memory page cache (was ~2MB default)
- `temp_store=MEMORY` → temp tables stay in RAM

**Single-connection `get_ohlcv`** — was opening 2 separate DB connections (one for aggregation, one for `FIRST_VALUE`/`LAST_VALUE` window functions); now reuses one connection

**Timing middleware** — `_timing_middleware` in `main.py`:
- Adds `X-Response-Time: <float>ms` to every response
- Logs `WARN SLOW GET /api/... 1234ms` for any endpoint >500ms

**Perf benchmark script** — `backend/scripts/perf_benchmark.py`:
- Run against live backend: `python3 backend/scripts/perf_benchmark.py --host http://localhost:8766`
- Shows cold + warm latency for 25 endpoints, exits 1 if any cold call >2s

## Test plan

- [x] 15 new TDD tests in `test_perf_optimizations.py` covering:
  - Timing middleware exports `_timing_middleware` and adds `X-Response-Time` header
  - DB indexes exist on `pattern_history` and `phase_snapshots` after `init_db()`
  - `open_db()` sets `cache_size` ≥ 8000 pages and `temp_store=MEMORY`
  - 6 expensive endpoints populate the in-memory cache on first call
- [x] All 1401 tests pass (`1386 existing + 15 new`)
- [x] `black` + no mypy errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)