### PR TITLE
fix(#186): double /api/api prefix + WebSocket alerts polling fallback

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1047,6 +1047,35 @@ async function renderMicrostructure() {
 }
 
 // ── WebSocket: Alerts ─────────────────────────────────────────────────────────
+let _alertsPollingInterval = null;
+
+function _startAlertsPolling() {
+  // Fallback: poll /alerts every 10s when WebSocket is unavailable
+  const statusEl = document.getElementById('header-status');
+  if (statusEl) {
+    statusEl.textContent = 'polling (WS unavailable)';
+    statusEl.className = 'disconnected';
+  }
+  if (_alertsPollingInterval) return; // already polling
+  let _lastAlertTs = 0;
+  const poll = async () => {
+    const data = await apiFetch('/alerts?limit=20');
+    if (!data || !data.data) return;
+    for (const a of data.data) {
+      if ((a.ts || 0) > _lastAlertTs) {
+        _lastAlertTs = a.ts || 0;
+        const text = a.description || a.message || null;
+        if (text) {
+          showAlertBanner(text);
+          appendAlertFeed(a);
+        }
+      }
+    }
+  };
+  poll();
+  _alertsPollingInterval = setInterval(poll, 10000);
+}
+
 function connectAlerts() {
   if (wsAlerts) {
     wsAlerts.close();
@@ -1054,16 +1083,24 @@ function connectAlerts() {
   }
 
   const url = WS + '/api/ws/alerts';
+  let wsOk = false;
+
   try {
     wsAlerts = new WebSocket(url);
   } catch (e) {
     console.warn('[WS] failed to create WebSocket:', e);
+    _startAlertsPolling();
     return;
   }
 
   const statusEl = document.getElementById('header-status');
 
   wsAlerts.onopen = () => {
+    wsOk = true;
+    if (_alertsPollingInterval) {
+      clearInterval(_alertsPollingInterval);
+      _alertsPollingInterval = null;
+    }
     if (statusEl) {
       statusEl.textContent = 'connected';
       statusEl.className = 'connected';
@@ -1087,7 +1124,13 @@ function connectAlerts() {
       statusEl.textContent = 'disconnected — reconnecting…';
       statusEl.className = 'disconnected';
     }
-    setTimeout(connectAlerts, 5000);
+    if (wsOk) {
+      // WS was working before — retry with backoff
+      setTimeout(connectAlerts, 5000);
+    } else {
+      // WS never connected (nginx not upgraded) — fall back to polling
+      _startAlertsPolling();
+    }
   };
 
   wsAlerts.onerror = (e) => {
@@ -5134,7 +5177,7 @@ async function renderFundingArbScanner() {
   if (!el) return;
 
   try {
-    const data = await apiFetch("/api/funding-arb-scanner");
+    const data = await apiFetch("/funding-arb-scanner");
     if (!data) { setErr('funding-arb-scanner-content'); return; }
 
     const { top_pairs, avg_spread_bps, extreme_count } = data;

--- a/tests/test_funding_arb_scanner.py
+++ b/tests/test_funding_arb_scanner.py
@@ -355,7 +355,8 @@ class TestFrontendJs:
         assert "renderFundingArbScanner" in js_content
 
     def test_api_endpoint_wired(self, js_content):
-        assert "/api/funding-arb-scanner" in js_content
+        # Path must not include /api prefix since apiFetch() prepends it automatically
+        assert "/funding-arb-scanner" in js_content
 
     def test_badge_id_referenced(self, js_content):
         assert "funding-arb-scanner-badge" in js_content

--- a/tests/test_issue_186_fixes.py
+++ b/tests/test_issue_186_fixes.py
@@ -1,0 +1,190 @@
+"""
+Tests for issue #186 fixes:
+  1. Double prefix /api/api/funding-arb-scanner — apiFetch("/api/...") → apiFetch("/...")
+  2. WebSocket /api/ws/alerts → polling fallback when WS unavailable
+  3. No continuous retry loop on alerts card
+  4. Backend /alerts GET endpoint returns correct shape
+  5. Frontend connectAlerts uses polling fallback pattern
+"""
+
+import os
+import re
+import sys
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.join(ROOT, "backend"))
+
+_js_cache: str | None = None
+_html_cache: str | None = None
+
+
+def _js() -> str:
+    global _js_cache
+    if _js_cache is None:
+        with open(os.path.join(ROOT, "frontend", "app.js"), encoding="utf-8") as f:
+            _js_cache = f.read()
+    return _js_cache
+
+
+def _html() -> str:
+    global _html_cache
+    if _html_cache is None:
+        with open(os.path.join(ROOT, "frontend", "index.html"), encoding="utf-8") as f:
+            _html_cache = f.read()
+    return _html_cache
+
+
+def _fn_body(js: str, fn_name: str) -> str:
+    """Extract function body (roughly) by finding its start and the next function."""
+    start = js.find(f"async function {fn_name}(")
+    if start == -1:
+        start = js.find(f"function {fn_name}(")
+    assert start != -1, f"Function {fn_name} not found in app.js"
+    nxt = js.find("\nasync function ", start + 1)
+    nxt2 = js.find("\nfunction ", start + 1)
+    end = min(x for x in [nxt, nxt2, len(js)] if x > start)
+    return js[start:end]
+
+
+# ── Group 1: No double /api/api prefix ───────────────────────────────────────
+
+
+class TestNoDoubleApiPrefix:
+    def test_no_apifetch_with_api_prefix(self):
+        """apiFetch already prepends /api — callers must not include /api in path."""
+        js = _js()
+        # Find all apiFetch calls with /api/ prefix (wrong)
+        matches = re.findall(r'apiFetch\(["\']\/api\/', js)
+        assert not matches, (
+            f"Found {len(matches)} apiFetch() call(s) with double /api/ prefix: {matches}. "
+            "apiFetch() already prepends API base which includes /api — remove the extra /api."
+        )
+
+    def test_funding_arb_scanner_uses_correct_path(self):
+        """renderFundingArbScanner must call apiFetch('/funding-arb-scanner'), not /api/..."""
+        body = _fn_body(_js(), "renderFundingArbScanner")
+        assert (
+            'apiFetch("/funding-arb-scanner")' in body
+            or "apiFetch('/funding-arb-scanner')" in body
+        ), (
+            "renderFundingArbScanner must call apiFetch('/funding-arb-scanner') — "
+            "without /api prefix since apiFetch adds it automatically."
+        )
+
+    def test_funding_arb_scanner_no_double_prefix(self):
+        """Specifically: /api/funding-arb-scanner must NOT appear inside apiFetch()."""
+        js = _js()
+        assert 'apiFetch("/api/funding-arb-scanner")' not in js, (
+            "apiFetch('/api/funding-arb-scanner') causes double prefix → /api/api/funding-arb-scanner. "
+            "Use apiFetch('/funding-arb-scanner') instead."
+        )
+
+
+# ── Group 2: Alerts WS polling fallback ──────────────────────────────────────
+
+
+class TestAlertsWsPollingFallback:
+    def test_connect_alerts_function_exists(self):
+        assert (
+            "function connectAlerts()" in _js() or "connectAlerts" in _js()
+        ), "connectAlerts function not found in app.js"
+
+    def test_polling_fallback_references_alerts_endpoint(self):
+        """Polling fallback must call /alerts endpoint (in connectAlerts or its helper)."""
+        js = _js()
+        connect_body = _fn_body(js, "connectAlerts")
+        # Either connectAlerts itself calls /alerts, or it delegates to a named helper
+        # that calls /alerts. Check the broader JS for the polling pattern.
+        has_alerts_poll = (
+            "apiFetch('/alerts" in js
+            or 'apiFetch("/alerts' in js
+            or "fetch('/api/alerts" in js
+            or 'fetch("/api/alerts' in js
+        )
+        # And connectAlerts must call the polling helper or directly poll
+        calls_polling = (
+            "_startAlertsPolling" in connect_body
+            or "apiFetch('/alerts" in connect_body
+            or 'apiFetch("/alerts' in connect_body
+            or "polling" in connect_body.lower()
+        )
+        assert (
+            has_alerts_poll
+        ), "app.js must contain an /alerts polling call for the WS fallback."
+        assert (
+            calls_polling
+        ), "connectAlerts must trigger polling (directly or via helper) on WS failure."
+
+    def test_polling_fallback_uses_setinterval_or_settimeout(self):
+        """Polling must use setInterval or setTimeout to repeat."""
+        body = _fn_body(_js(), "connectAlerts")
+        assert "setInterval" in body or "setTimeout" in body, (
+            "connectAlerts polling fallback must use setInterval or setTimeout "
+            "to repeat the poll."
+        )
+
+    def test_ws_error_does_not_trigger_immediate_reconnect_loop(self):
+        """onerror must not call connectAlerts() directly — that causes a tight retry loop."""
+        body = _fn_body(_js(), "connectAlerts")
+        # Find onerror handler
+        err_start = body.find("wsAlerts.onerror")
+        assert err_start != -1, "wsAlerts.onerror handler not found"
+        err_snippet = body[err_start : err_start + 300]
+        # onerror must not call connectAlerts() without a delay/fallback check
+        assert "setTimeout(connectAlerts" not in err_snippet, (
+            "wsAlerts.onerror must not call setTimeout(connectAlerts) — "
+            "that creates a retry loop on WS failure. Use polling fallback instead."
+        )
+
+    def test_ws_fallback_flag_or_mode_tracking(self):
+        """connectAlerts must track whether WS is available to choose polling vs WS."""
+        body = _fn_body(_js(), "connectAlerts")
+        # Should have some variable that tracks WS connected/failed state
+        has_flag = (
+            "wsConnected" in body
+            or "_wsOk" in body
+            or "polling" in body
+            or "fallback" in body
+            or "usePoll" in body
+            or "wsOk" in body
+        )
+        assert has_flag, (
+            "connectAlerts must track whether WS connected successfully to decide "
+            "whether to use polling fallback."
+        )
+
+
+# ── Group 3: Backend /alerts endpoint ────────────────────────────────────────
+
+
+class TestBackendAlertsEndpoint:
+    def test_alerts_endpoint_exists_in_api(self):
+        """Backend must have GET /alerts endpoint."""
+        with open(os.path.join(ROOT, "backend", "api.py"), encoding="utf-8") as f:
+            api_src = f.read()
+        assert (
+            '@router.get("/alerts")' in api_src
+        ), "Backend api.py must have @router.get('/alerts') endpoint for polling fallback."
+
+    def test_alerts_endpoint_referenced_in_js(self):
+        """Frontend must reference /alerts endpoint (for polling)."""
+        js = _js()
+        assert "/alerts" in js, "app.js must reference /alerts endpoint"
+
+
+# ── Group 4: Existing funding arb scanner test compatibility ─────────────────
+
+
+class TestFundingArbScannerEndpointPath:
+    def test_funding_arb_scanner_path_without_api_prefix(self):
+        """The funding arb scanner API call must use path without /api prefix."""
+        js = _js()
+        # The correct call
+        assert (
+            "/funding-arb-scanner" in js
+        ), "app.js must reference /funding-arb-scanner endpoint"
+
+    def test_render_funding_arb_scanner_exists(self):
+        assert "renderFundingArbScanner" in _js()


### PR DESCRIPTION
## Summary
- **Bug 1 – WS /api/ws/alerts loop**: `connectAlerts()` now tracks a `wsOk` flag. If the WebSocket closes before ever opening (nginx missing upgrade headers), it falls back to `_startAlertsPolling()` which polls `/alerts?limit=20` every 10 s — no more tight retry loop.
- **Bug 2 – Double /api prefix**: Changed `apiFetch("/api/funding-arb-scanner")` → `apiFetch("/funding-arb-scanner")`. `apiFetch()` already prepends the `/api` base, so the old code produced `/api/api/funding-arb-scanner` → 404.
- Updated stale assertion in `test_funding_arb_scanner.py` to match the corrected path.

## Test plan
- [ ] 12 new tests in `tests/test_issue_186_fixes.py` all pass
- [ ] `tests/test_funding_arb_scanner.py::TestFrontendJs::test_api_endpoint_wired` updated and passes
- [ ] Full suite: 4362 passed, 0 new failures
- [ ] Alerts card no longer shows continuous retry loop when WS is unavailable
- [ ] `/api/funding-arb-scanner` now resolves (no double prefix)

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)